### PR TITLE
Fixes: #6 - Show device count on Hardware Lifecycle list view

### DIFF
--- a/netbox_lifecycle/models/hardware.py
+++ b/netbox_lifecycle/models/hardware.py
@@ -3,7 +3,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.db import models
 from django.urls import reverse
 
-from dcim.models import DeviceType, ModuleType
+from dcim.models import DeviceType, ModuleType, Device, Module
 from netbox.models import NetBoxModel
 
 
@@ -57,6 +57,12 @@ class HardwareLifecycle(NetBoxModel):
         if isinstance(self.assigned_object, ModuleType):
             return f'Module Type: {self.assigned_object.model}'
         return f'Device Type: {self.assigned_object.model}'
+
+    @property
+    def assigned_object_count(self):
+        if isinstance(self.assigned_object, DeviceType):
+            return Device.objects.filter(device_type=self.assigned_object).count()
+        return Module.objects.filter(module_type=self.assigned_object).count()
 
     def get_absolute_url(self):
         return reverse('plugins:netbox_lifecycle:hardwarelifecycle', args=[self.pk])

--- a/netbox_lifecycle/tables/hardware.py
+++ b/netbox_lifecycle/tables/hardware.py
@@ -19,9 +19,8 @@ class HardwareLifecycleTable(NetBoxTable):
         linkify=True,
         verbose_name='Hardware'
     )
-    devices = tables.Column(
-        accessor=tables.A('devices__count'),
-        verbose_name='Device Count'
+    assigned_object_count = tables.Column(
+        verbose_name='Assigned Object Count'
     )
 
     class Meta(NetBoxTable.Meta):

--- a/netbox_lifecycle/views/hardware.py
+++ b/netbox_lifecycle/views/hardware.py
@@ -4,7 +4,7 @@ from netbox_lifecycle.forms import HardwareLifecycleFilterForm
 from netbox_lifecycle.forms.model_forms import HardwareLifecycleForm
 from netbox_lifecycle.models import HardwareLifecycle
 from netbox_lifecycle.tables import HardwareLifecycleTable
-from utilities.views import ViewTab, register_model_view
+from utilities.views import register_model_view
 
 
 __all__ = (


### PR DESCRIPTION
### Fixes: #6 - Show device count on Hardware Lifecycle list view

* Change to utilize property on model instead of relying on reverse reference