### PR TITLE
Add dates to device and devicetype pages

### DIFF
--- a/netbox_lifecycle/template_content.py
+++ b/netbox_lifecycle/template_content.py
@@ -1,0 +1,42 @@
+
+from datetime import datetime
+
+from django.core.exceptions import ObjectDoesNotExist
+from django.template import Template
+from netbox.plugins import PluginTemplateExtension
+
+from .models import hardware, contract
+
+class DeviceHardwareInfoExtension(PluginTemplateExtension):
+    model = 'dcim.device'
+
+    def right_page(self):
+        object = self.context.get('object')
+        support_contract = contract.SupportContractAssignment.objects.filter(device_id=self.context['object'].id).first()
+        hardware_lifecycle = hardware.HardwareLifecycle.objects.filter(assigned_object_id=self.context['object'].device_type.id).first()
+        context = {'support_contract': support_contract, 'hardware_lifecycle': hardware_lifecycle}
+        return self.render('netbox_lifecycle/inc/support_contract_info.html', extra_context=context)
+        
+class DeviceHardwareLifecycleInfo(DeviceHardwareInfoExtension):
+    model = 'dcim.device'
+    kind = 'device'
+
+
+class DeviceTypeInfoExtension(PluginTemplateExtension):
+    model = 'dcim.devicetype'
+
+    def right_page(self):
+        object = self.context.get('object')
+        hardware_lifecycle = hardware.HardwareLifecycle.objects.filter(assigned_object_id=self.context['object'].id).first()
+        context = {'hardware_lifecycle': hardware_lifecycle}
+        return self.render('netbox_lifecycle/inc/device_lifecycle_info.html', extra_context=context)
+
+class DeviceTypeHardwareLifecycleInfo(DeviceTypeInfoExtension):
+    model = 'dcim.devicetype'
+    kind = 'devicetype'
+
+
+template_extensions = (
+    DeviceHardwareLifecycleInfo,
+    DeviceTypeHardwareLifecycleInfo,
+)

--- a/netbox_lifecycle/templates/netbox_lifecycle/inc/device_lifecycle_info.html
+++ b/netbox_lifecycle/templates/netbox_lifecycle/inc/device_lifecycle_info.html
@@ -1,0 +1,36 @@
+
+{% load filters %}
+{% load helpers %}
+{# renders panel on object (device) with hardware lifecycle info assigned to it #}
+
+<div class="card">
+  <h5 class="card-header">Lifecycle Dates</h5>
+  {% if hardware_lifecycle %}
+  <table class="table table-hover attr-table">
+    <tr>
+      <td>End of Sale</td>
+      <td><span {{ hardware_lifecycle.end_of_sale|date_badge_class }}>{{ hardware_lifecycle.end_of_sale }}</span></td>
+    </tr>
+    <tr>
+      <td>End of Maintenance Updates</td>
+      <td><span {{ hardware_lifecycle.end_of_maintenance|date_badge_class }}>{{ hardware_lifecycle.end_of_maintenance }}</span></td>
+    </tr>
+    <tr>
+      <td>End of Security Updates</td>
+      <td><span {{ hardware_lifecycle.end_of_security|date_badge_class }}>{{ hardware_lifecycle.end_of_security }}</span></td>
+    </tr>
+    <tr>
+      <td>Last Support Contract Purchase Date</td>
+      <td><span {{ hardware_lifecycle.last_contract_date|date_badge_class }}>{{ hardware_lifecycle.last_contract_date }}</span></td>
+    </tr>
+    <tr>
+      <td>End of Support</td>
+      <td><span {{ hardware_lifecycle.end_of_support|date_badge_class }}>{{ hardware_lifecycle.end_of_support }}</span></td>
+    </tr>
+  </table>
+  {% else %}
+  <div class="card-body"><span class="text-muted">No Lifecycle Dates Defined</span></div>
+  {% endif %}
+</div>
+
+

--- a/netbox_lifecycle/templates/netbox_lifecycle/inc/support_contract_info.html
+++ b/netbox_lifecycle/templates/netbox_lifecycle/inc/support_contract_info.html
@@ -1,0 +1,32 @@
+
+{% load filters %}
+{% load helpers %}
+{# renders panel on object (device) with support contract info assigned to it #}
+
+<div class="card">
+  <h5 class="card-header">Support Contract</h5>
+  {% if support_contract %}
+  <table class="table table-hover attr-table">
+    <tr>
+      <th scope="row"><span title="Contract Number">Contract Number</span></th>
+      <td>{{ support_contract.contract.contract_id|linkify|placeholder }}</td>
+    </tr>
+    <tr>
+      <th scope="row">Support SKU</th>
+      <td>{{ support_contract.sku }}</td>
+    </tr>
+    <tr>
+      <th scope="row">Start Date</th>
+      <td>{{ support_contract.contract.start }}</td>
+    </tr>
+    <tr>
+      <th scope="row">End Date</th>
+      <td><span {{ support_contract.contract.end|date_badge_class }}>{{ support_contract.contract.end }}</span></td>
+    </tr>
+  </table>
+  {% else %}
+  <div class="card-body"><span class="text-muted">No Support Contract Assigned<span></div>
+  {% endif %}
+</div>
+
+{% include "netbox_lifecycle/inc/device_lifecycle_info.html" %}

--- a/netbox_lifecycle/templatetags/filters.py
+++ b/netbox_lifecycle/templatetags/filters.py
@@ -1,0 +1,27 @@
+from datetime import datetime, date
+from dateutil.relativedelta import relativedelta
+from django import template
+from django.utils.safestring import mark_safe
+
+register = template.Library()
+
+
+def is_expired(value):
+    return value < datetime.now().date()
+
+
+def expires_within_six_months(value):
+    return value < (date.today() + relativedelta(months=+6))
+
+
+@register.filter(is_safe=True)
+def date_badge_class(value):
+    if not value:
+        return
+
+    if is_expired(value):
+        return mark_safe('class="badge text-bg-danger"')
+    elif expires_within_six_months(value):
+        return mark_safe('class="badge text-bg-warning"')
+    else:
+        return mark_safe('class="badge text-bg-success"')


### PR DESCRIPTION
Hey, hoping this can help close out Issue #5.  This adds dates to device and devicetype pages.  Device pages shows any support contracts and lifecycle dates.  Devicetype page shows just the lifecycle dates.

Let me know any issues.  First attempt at a PR here so if I've done anything wrong apols.  Would be good to get feedback if that's the case.