### PR TITLE
Fix Contracts not showing up in navigation

### DIFF
--- a/netbox_lifecycle/navigation.py
+++ b/netbox_lifecycle/navigation.py
@@ -19,7 +19,7 @@ skus = PluginMenuItem(
 contracts = PluginMenuItem(
     link='plugins:netbox_lifecycle:supportcontract_list',
     link_text='Contracts',
-    permissions=['netbox_lifecycle.view_supportcontrnact'],
+    permissions=['netbox_lifecycle.view_supportcontract'],
 )
 contract_assignments = PluginMenuItem(
     link='plugins:netbox_lifecycle:supportcontractassignment_list',


### PR DESCRIPTION
I noticed that the Contracts navigation item does not appear even when the permission is assigned to the user:
![2025-01-15 12_55_29-Users _ NetBox and 16 more pages - Work - Microsoft​ Edge](https://github.com/user-attachments/assets/59235459-5a46-4014-920a-9466c61bf7bb)

It was resolved by correcting a typo in navigation.py