### PR TITLE
Navigation and link improvements

### DIFF
--- a/netbox_lifecycle/navigation.py
+++ b/netbox_lifecycle/navigation.py
@@ -1,49 +1,57 @@
-from netbox.plugins import PluginMenuItem, PluginMenu
+from netbox.plugins import PluginMenu, PluginMenuButton, PluginMenuItem
 
-lifecycle = PluginMenuItem(
-    link='plugins:netbox_lifecycle:hardwarelifecycle_list',
-    link_text='Hardware Lifecycle',
-    permissions=['netbox_lifecycle.view_hardwarelifecycle'],
-)
+APP_LABEL = 'netbox_lifecycle'
 
-vendors = PluginMenuItem(
-    link='plugins:netbox_lifecycle:vendor_list',
-    link_text='Vendors',
-    permissions=['netbox_lifecycle.view_vendor'],
-)
-skus = PluginMenuItem(
-    link='plugins:netbox_lifecycle:supportsku_list',
-    link_text='Support SKUs',
-    permissions=['netbox_lifecycle.view_supportsku'],
-)
-contracts = PluginMenuItem(
-    link='plugins:netbox_lifecycle:supportcontract_list',
-    link_text='Contracts',
-    permissions=['netbox_lifecycle.view_supportcontract'],
-)
-contract_assignments = PluginMenuItem(
-    link='plugins:netbox_lifecycle:supportcontractassignment_list',
-    link_text='Contract Assignments',
-    permissions=['netbox_lifecycle.view_supportcontractassignment'],
-)
-licenses = PluginMenuItem(
-    link='plugins:netbox_lifecycle:license_list',
-    link_text='Licenses',
-    permissions=['netbox_lifecycle.view_license'],
-)
-license_assignments = PluginMenuItem(
-    link='plugins:netbox_lifecycle:licenseassignment_list',
-    link_text='License Assignments',
-    permissions=['netbox_lifecycle.view_licenseassignment'],
-)
 
+def get_model_buttons(model_name, actions=('add',)):
+    buttons = []
+
+    if 'add' in actions:
+        buttons.append(
+            PluginMenuButton(
+                link=f'plugins:{APP_LABEL}:{model_name}_add',
+                title='Add',
+                icon_class='mdi mdi-plus-thick',
+                permissions=[f'{APP_LABEL}.add_{model_name}'],
+            )
+        )
+
+    if 'import' in actions:
+        buttons.append(
+            PluginMenuButton(
+                link=f'plugins:{APP_LABEL}:{model_name}_import',
+                title='Import',
+                icon_class='mdi mdi-upload',
+                permissions=[f'{APP_LABEL}.add_{model_name}'],
+            )
+        )
+
+    return buttons
+
+
+def get_model_item(model_name, label, actions=('add',)):
+    return PluginMenuItem(
+        link=f'plugins:{APP_LABEL}:{model_name}_list',
+        link_text=label,
+        permissions=[f'{APP_LABEL}.view_{model_name}'],
+        buttons=get_model_buttons(model_name, actions),
+    )
+
+
+hardwarelifecycle_item = get_model_item('hardwarelifecycle', 'Hardware Lifecycle')
+vendor_item = get_model_item('vendor', 'Vendors')
+supportsku_item = get_model_item('supportsku', 'Support SKUs')
+supportcontract_item = get_model_item('supportcontract', 'Contracts')
+supportcontractassignment_item = get_model_item('supportcontractassignment', 'Contract Assignments')
+license_item = get_model_item('license', 'Licenses')
+licenseassignment_item = get_model_item('licenseassignment', 'License Assignments')
 
 menu = PluginMenu(
     label='Hardware Lifecycle',
     groups=(
-        ('Lifecycle', (lifecycle, )),
-        ('Support Contracts', (vendors, skus, contracts, contract_assignments)),
-        ('Licensing', (licenses, license_assignments)),
+        ('Lifecycle', (hardwarelifecycle_item,)),
+        ('Support Contracts', (vendor_item, supportsku_item, supportcontract_item, supportcontractassignment_item)),
+        ('Licensing', (license_item, licenseassignment_item)),
     ),
-    icon_class='mdi mdi-server'
+    icon_class='mdi mdi-server',
 )

--- a/netbox_lifecycle/tables/contract.py
+++ b/netbox_lifecycle/tables/contract.py
@@ -30,6 +30,14 @@ class VendorTable(NetBoxTable):
 
 
 class SupportSKUTable(NetBoxTable):
+    sku = tables.Column(
+        verbose_name=_('SKU'),
+        linkify=True,
+    )
+    manufacturer = tables.Column(
+        verbose_name=_('Manufacturer'),
+        linkify=True,
+    )
 
     class Meta(NetBoxTable.Meta):
         model = SupportSKU

--- a/netbox_lifecycle/tables/contract.py
+++ b/netbox_lifecycle/tables/contract.py
@@ -67,9 +67,9 @@ class SupportContractAssignmentTable(NetBoxTable):
         linkify=True,
     )
     device_name = tables.Column(
-        verbose_name=_('Device Name'),
-        accessor='device__name',
-        linkify=False,
+        verbose_name=_("Device Name"),
+        accessor="device__name",
+        linkify={"viewname": "dcim:device", "args": [tables.A("device_id")]},
         orderable=True,
     )
     device_serial = tables.Column(

--- a/netbox_lifecycle/tables/contract.py
+++ b/netbox_lifecycle/tables/contract.py
@@ -67,9 +67,9 @@ class SupportContractAssignmentTable(NetBoxTable):
         linkify=True,
     )
     device_name = tables.Column(
-        verbose_name=_("Device Name"),
-        accessor="device__name",
-        linkify={"viewname": "dcim:device", "args": [tables.A("device_id")]},
+        verbose_name=_('Device Name'),
+        accessor='device__name',
+        linkify={'viewname': 'dcim:device', 'args': [tables.A('device_id')]},
         orderable=True,
     )
     device_serial = tables.Column(

--- a/netbox_lifecycle/templates/netbox_lifecycle/inc/support_contract_info.html
+++ b/netbox_lifecycle/templates/netbox_lifecycle/inc/support_contract_info.html
@@ -8,12 +8,16 @@
   {% if support_contract %}
   <table class="table table-hover attr-table">
     <tr>
+      <th scope="row">Vendor</th>
+      <td><a href="{{ support_contract.contract.vendor.get_absolute_url }}">{{ support_contract.contract.vendor }}</a></td>
+    </tr>
+    <tr>
       <th scope="row"><span title="Contract Number">Contract Number</span></th>
-      <td>{{ support_contract.contract.contract_id|linkify|placeholder }}</td>
+      <td><a href="{{ support_contract.contract.get_absolute_url }}">{{ support_contract.contract.contract_id }}</a></td>
     </tr>
     <tr>
       <th scope="row">Support SKU</th>
-      <td>{{ support_contract.sku }}</td>
+      <td><a href="{{ support_contract.sku.get_absolute_url }}">{{ support_contract.sku }}</a></td>
     </tr>
     <tr>
       <th scope="row">Start Date</th>

--- a/netbox_lifecycle/templates/netbox_lifecycle/supportcontract.html
+++ b/netbox_lifecycle/templates/netbox_lifecycle/supportcontract.html
@@ -6,64 +6,74 @@
 {% load plugins %}
 {% load tabs %}
 
+{% if perms.netbox_lifecycle.add_supportcontractassignment %}
+{% block extra_controls %}
+  <a href="{% url 'plugins:netbox_lifecycle:supportcontractassignment_add' %}?contract={{ object.pk }}"
+    class="btn btn-primary">
+    <span class="mdi mdi-plus-thick" aria-hidden="true"></span> Add Assignment
+  </a>  
+{% endblock %}
+{% endif %}
+
+
 {% block content %}
-  <div class="row">
-    <div class="col col-md-6">
-      <div class="card">
-        <h5 class="card-header">Contract</h5>
-        <div class="card-body">
-          <table class="table table-hover attr-table">
-            <tr>
-              <th>Manufacturer</th>
-              <td>{{ object.manufacturer|linkify }}</td>
-            </tr>
-            <tr>
-              <th>Vendor</th>
-              <td>{{ object.vendor|linkify }}</td>
-            </tr>
-            <tr>
-              <th>Contract ID</th>
-              <td>{{ object.contract_id }}</td>
-            </tr>
-            <tr>
-              <th>Description</th>
-              <td>{{ object.description }}</td>
-            </tr>
-          </table>
-        </div>
+<div class="row">
+  <div class="col col-md-6">
+    <div class="card">
+      <h5 class="card-header">Contract</h5>
+      <div class="card-body">
+        <table class="table table-hover attr-table">
+          <tr>
+            <th>Manufacturer</th>
+            <td>{{ object.manufacturer|linkify }}</td>
+          </tr>
+          <tr>
+            <th>Vendor</th>
+            <td>{{ object.vendor|linkify }}</td>
+          </tr>
+          <tr>
+            <th>Contract ID</th>
+            <td>{{ object.contract_id }}</td>
+          </tr>
+          <tr>
+            <th>Description</th>
+            <td>{{ object.description }}</td>
+          </tr>
+        </table>
       </div>
-      <div class="card">
-        <h5 class="card-header">Dates</h5>
-        <div class="card-body">
-          <table class="table table-hover attr-table">
-            <tr>
-              <th>Start</th>
-              <td>{{ object.start }}</td>
-            </tr>
-            <tr>
-              <th>Last renewal</th>
-              <td>{{ object.renewal }}</td>
-            </tr>
-            <tr>
-              <th>End</th>
-              <td>{{ object.end }}</td>
-            </tr>
-          </table>
-        </div>
+    </div>
+    <div class="card">
+      <h5 class="card-header">Dates</h5>
+      <div class="card-body">
+        <table class="table table-hover attr-table">
+          <tr>
+            <th>Start</th>
+            <td>{{ object.start }}</td>
+          </tr>
+          <tr>
+            <th>Last renewal</th>
+            <td>{{ object.renewal }}</td>
+          </tr>
+          <tr>
+            <th>End</th>
+            <td>{{ object.end }}</td>
+          </tr>
+        </table>
       </div>
-      {% plugin_left_page object %}
-      {% include 'inc/panels/tags.html' %}
     </div>
-    <div class="col col-md-6">
-      {% include 'inc/panels/related_objects.html' %}
-      {% include 'inc/panels/custom_fields.html' %}
-      {% include 'inc/panels/comments.html' %}
-      {% plugin_right_page object %}
-    </div>
+    {% plugin_left_page object %}
+    {% include 'inc/panels/tags.html' %}
   </div>
-  <div class="row">
-    <div class="col col-md-12">
-      {% plugin_full_width_page object %}
-    </div>
+  <div class="col col-md-6">
+    {% include 'inc/panels/related_objects.html' %}
+    {% include 'inc/panels/custom_fields.html' %}
+    {% include 'inc/panels/comments.html' %}
+    {% plugin_right_page object %}
   </div>
+</div>
+<div class="row">
+  <div class="col col-md-12">
+    {% plugin_full_width_page object %}
+  </div>
+</div>
 {% endblock %}


### PR DESCRIPTION
I've made some modifications to improve navigability based on my usage of the plugin.

- SupportContractAssignmentTable has a link to the device
- SupportSKUTable has links to SKU and Manufacturer
- SupportContract page has an extra button "Add Assignment" which can save an unnecessary page load
- Added Vendor to the support_contract_info template and made it clickable
- Made the Contract Number and Support SKU clickable
  - Removed "placeholder" filter since contract_id will always be populated
  - Removed "linkify" filter since I believe this was an incorrect usage based on the docs
- Simplify menu generation based on a function, which generates "add" buttons in the UI, and import buttons could be added later