### PR TITLE
Close #76 - Get related models for Vendor view

### DIFF
--- a/netbox_lifecycle/views/contract.py
+++ b/netbox_lifecycle/views/contract.py
@@ -8,7 +8,7 @@ from netbox_lifecycle.forms import SupportContractFilterForm, VendorFilterForm, 
 from netbox_lifecycle.models import SupportContract, Vendor, LicenseAssignment, SupportContractAssignment, SupportSKU
 from netbox_lifecycle.tables import SupportContractTable, VendorTable, LicenseAssignmentTable, \
     SupportContractAssignmentTable, SupportSKUTable
-from utilities.views import ViewTab, register_model_view
+from utilities.views import ViewTab, register_model_view, GetRelatedModelsMixin
 
 
 __all__ = (
@@ -56,8 +56,18 @@ class VendorListView(ObjectListView):
 
 
 @register_model_view(Vendor)
-class VendorView(ObjectView):
+class VendorView(GetRelatedModelsMixin, ObjectView):
     queryset = Vendor.objects.all()
+
+    def get_extra_context(self, request, instance):
+        assignments = SupportContractAssignment.objects.filter(
+            contract__vendor=instance
+        )
+        return {
+            'related_models': self.get_related_models(
+                request, instance, extra=[(assignments, 'contract_id')]
+            ),
+        }
 
 
 @register_model_view(Vendor, 'edit')


### PR DESCRIPTION
Closes #76 

- GetRelatedModelsMixin is imported to get direct relations which currently are License Assignment and Contract
- SupportContractAssignment indirect relation is grabbed as it is often relevant to me (i.e. find all devices assigned a Dell support contract when looking at the Dell vendor page)