### PR TITLE
Closes #86 - Add Licenses card in Device View

### DIFF
--- a/netbox_lifecycle/template_content.py
+++ b/netbox_lifecycle/template_content.py
@@ -9,7 +9,8 @@ from .models import hardware, contract, license
 class DeviceHardwareInfoExtension(PluginTemplateExtension):
     def right_page(self):
         object = self.context.get('object')
-        licenses = license.LicenseAssignment.objects.filter(device_id=self.context['object'].id)
+        max_items_display = 5
+        licenses = license.LicenseAssignment.objects.filter(device_id=self.context['object'].id)[:max_items_display]
         support_contract = contract.SupportContractAssignment.objects.filter(device_id=self.context['object'].id).first()
         match self.kind:
             case "device":
@@ -24,7 +25,8 @@ class DeviceHardwareInfoExtension(PluginTemplateExtension):
                 content_type = ContentType.objects.get(app_label="dcim", model=self.kind)
                 lifecycle_info = hardware.HardwareLifecycle.objects.filter(assigned_object_id=self.context['object'].id,
                                                                            assigned_object_type_id=content_type.id).first()
-        context = {'licenses': licenses, 'support_contract': support_contract, 'lifecycle_info': lifecycle_info}
+        context = {'max_items_display': max_items_display, 'licenses': licenses, 'support_contract': support_contract,
+                   'lifecycle_info': lifecycle_info}
         return self.render('netbox_lifecycle/inc/licenses_info.html', extra_context=context)
 
 

--- a/netbox_lifecycle/template_content.py
+++ b/netbox_lifecycle/template_content.py
@@ -10,18 +10,20 @@ class DeviceHardwareInfoExtension(PluginTemplateExtension):
     def right_page(self):
         object = self.context.get('object')
         max_items_display = 5
-        licenses = license.LicenseAssignment.objects.filter(device_id=self.context['object'].id)[:max_items_display]
-        support_contract = contract.SupportContractAssignment.objects.filter(device_id=self.context['object'].id).first()
         match self.kind:
             case "device":
+                licenses = license.LicenseAssignment.objects.filter(device_id=self.context['object'].id)[:max_items_display]
+                support_contract = contract.SupportContractAssignment.objects.filter(device_id=self.context['object'].id).first()
                 content_type = ContentType.objects.get(app_label="dcim", model="devicetype")
                 lifecycle_info = hardware.HardwareLifecycle.objects.filter(assigned_object_id=self.context['object'].device_type_id,
                                                                            assigned_object_type_id=content_type.id).first()
             case "module":
+                licenses = None
                 content_type = ContentType.objects.get(app_label="dcim", model="moduletype")
                 lifecycle_info = hardware.HardwareLifecycle.objects.filter(assigned_object_id=self.context['object'].module_type_id,
                                                                            assigned_object_type_id=content_type.id).first()
             case "devicetype" | "moduletype":
+                licenses = None
                 content_type = ContentType.objects.get(app_label="dcim", model=self.kind)
                 lifecycle_info = hardware.HardwareLifecycle.objects.filter(assigned_object_id=self.context['object'].id,
                                                                            assigned_object_type_id=content_type.id).first()

--- a/netbox_lifecycle/template_content.py
+++ b/netbox_lifecycle/template_content.py
@@ -3,12 +3,13 @@ from django.contrib.contenttypes.models import ContentType
 from django.template import Template
 from netbox.plugins import PluginTemplateExtension
 
-from .models import hardware, contract
+from .models import hardware, contract, license
 
 
 class DeviceHardwareInfoExtension(PluginTemplateExtension):
     def right_page(self):
         object = self.context.get('object')
+        licenses = license.LicenseAssignment.objects.filter(device_id=self.context['object'].id)
         support_contract = contract.SupportContractAssignment.objects.filter(device_id=self.context['object'].id).first()
         match self.kind:
             case "device":
@@ -23,8 +24,8 @@ class DeviceHardwareInfoExtension(PluginTemplateExtension):
                 content_type = ContentType.objects.get(app_label="dcim", model=self.kind)
                 lifecycle_info = hardware.HardwareLifecycle.objects.filter(assigned_object_id=self.context['object'].id,
                                                                            assigned_object_type_id=content_type.id).first()
-        context = {'support_contract': support_contract, 'lifecycle_info': lifecycle_info}
-        return self.render('netbox_lifecycle/inc/support_contract_info.html', extra_context=context)
+        context = {'licenses': licenses, 'support_contract': support_contract, 'lifecycle_info': lifecycle_info}
+        return self.render('netbox_lifecycle/inc/licenses_info.html', extra_context=context)
 
 
 class TypeInfoExtension(PluginTemplateExtension):

--- a/netbox_lifecycle/templates/netbox_lifecycle/inc/licenses_info.html
+++ b/netbox_lifecycle/templates/netbox_lifecycle/inc/licenses_info.html
@@ -1,0 +1,70 @@
+
+{% load filters %}
+{% load helpers %}
+{# renders panel on object (device) with licenses assigned to it #}
+
+<div class="card">
+  <h5 class="card-header">
+    Licenses
+    <div class="card-actions">
+		  <a href="{% url 'plugins:netbox_lifecycle:licenseassignment_add' %}?device={{ object.pk }}&return_url={% url 'dcim:device' pk=object.pk %}" class="btn btn-ghost-primary btn-sm">
+		    <span class="mdi mdi-plus-thick" aria-hidden="true"></span> Assign License
+		  </a>
+	  </div>
+  </h5>
+  <table class="table table-hover object-list">
+    <thead hx-target="closest">
+        <tr>
+            <th>Vendor</th>
+            <th>Manufacturer</th>
+            <th>Name</th>
+            <th>Quantity</th>
+            <th>Description</th>
+            <th></th>
+        </tr>
+    </thead>
+    {% if licenses %}
+    <tbody>
+      {% for license in licenses %}
+      <tr class="even">
+        <td>{{ license.vendor|linkify|placeholder }}</td>
+        <td>{{ license.license.manufacturer|linkify|placeholder }}</td>
+        <td>{{ license.license|linkify|placeholder }}</td>
+        <td>{{ license.quantity|placeholder }}</td>
+        <td>{{ license.description|placeholder }}</td>
+        <td class="noprint text-end text-nowrap">
+          <span class="btn-group dropdown">
+            <a class="btn btn-sm btn-warning" href="{% url 'plugins:netbox_lifecycle:licenseassignment_edit' pk=license.pk %}?return_url={% url 'dcim:device' pk=object.pk %}" type="button" aria-label="Edit">
+              <i class="mdi mdi-pencil"></i>
+            </a>  
+            <a class="btn btn-sm btn-warning dropdown-toggle" type="button" data-bs-toggle="dropdown" style="padding-left: 2px">  
+              <span class="visually-hidden">Toggle Dropdown</span>
+            </a> 
+            <ul class="dropdown-menu">
+              <li>
+                <a class="dropdown-item" href="{% url 'plugins:netbox_lifecycle:licenseassignment_delete' pk=license.pk %}?return_url={% url 'dcim:device' pk=object.pk %}">
+                  <i class="mdi mdi-trash-can-outline"></i> Delete
+                </a>
+              </li>
+              <li>
+                <a class="dropdown-item" href="{% url 'plugins:netbox_lifecycle:licenseassignment_changelog' pk=license.pk %}?return_url={% url 'dcim:device' pk=object.pk %}">
+                  <i class="mdi mdi-history"></i> Changelog
+                </a>
+              </li>
+            </ul>
+          </span>
+        </td>
+      </tr>
+      {% endfor %}
+    </tbody>
+    {% else %}
+    <tbody>
+        <tr>
+            <td colspan="6" class="text-center text-muted">— No License Assigned —</td>
+        </tr>
+    </tbody>
+    {% endif %}
+  </table>
+</div>
+
+{% include "netbox_lifecycle/inc/support_contract_info.html" %}

--- a/netbox_lifecycle/templates/netbox_lifecycle/inc/licenses_info.html
+++ b/netbox_lifecycle/templates/netbox_lifecycle/inc/licenses_info.html
@@ -37,7 +37,7 @@
             <a class="btn btn-sm btn-warning" href="{% url 'plugins:netbox_lifecycle:licenseassignment_edit' pk=license.pk %}?return_url={% url 'dcim:device' pk=object.pk %}" type="button" aria-label="Edit">
               <i class="mdi mdi-pencil"></i>
             </a>  
-            <a class="btn btn-sm btn-warning dropdown-toggle" type="button" data-bs-toggle="dropdown" style="padding-left: 2px">  
+            <a class="btn btn-sm btn-warning dropdown-toggle" type="button" data-bs-toggle="dropdown" style="padding-left: 2px">
               <span class="visually-hidden">Toggle Dropdown</span>
             </a> 
             <ul class="dropdown-menu">
@@ -56,6 +56,13 @@
         </td>
       </tr>
       {% endfor %}
+      {% if licenses|length == max_items_display %}
+      <tr class="even">
+        <td colspan="6">
+          <small class="text-end text-muted">Max Licenses display reached: <a href="{% url 'plugins:netbox_lifecycle:licenseassignment_list'%}?device_id={{ object.pk }}">Show all Licenses</a></small>
+        </td>
+      </tr>
+      {% endif %}
     </tbody>
     {% else %}
     <tbody>


### PR DESCRIPTION
Update after closing of #90 (see comments for details).

Closes #86 to add a new card to reference *Licenses* assigned to *Device*.

As this new card is displaying a table with possibly multiple *Licenses* assigned to the device, I've set a limit display of 5 *Licenses* in the card. This could be discussed, but this avoids the usage of htmx and to comply with more complex cards as *Services* or *Images*.