### PR TITLE
Fixes: #99 - Add missing FilterSets to the API ViewSets

### DIFF
--- a/netbox_lifecycle/api/views/contract.py
+++ b/netbox_lifecycle/api/views/contract.py
@@ -1,8 +1,10 @@
-
 from netbox.api.viewsets import NetBoxModelViewSet
 from netbox_lifecycle.api.serializers import VendorSerializer, SupportContractSerializer, \
     SupportContractAssignmentSerializer, SupportSKUSerializer
+from netbox_lifecycle.filtersets import SupportSKUFilterSet, VendorFilterSet, SupportContractFilterSet, \
+    SupportContractAssignmentFilterSet
 from netbox_lifecycle.models import Vendor, SupportContract, SupportContractAssignment, SupportSKU
+
 
 __all__ = (
     'VendorViewSet',
@@ -15,18 +17,22 @@ __all__ = (
 class VendorViewSet(NetBoxModelViewSet):
     queryset = Vendor.objects.all()
     serializer_class = VendorSerializer
+    filterset_class = VendorFilterSet
 
 
 class SupportSKUViewSet(NetBoxModelViewSet):
     queryset = SupportSKU.objects.all()
     serializer_class = SupportSKUSerializer
+    filterset_class = SupportSKUFilterSet
 
 
 class SupportContractViewSet(NetBoxModelViewSet):
     queryset = SupportContract.objects.all()
     serializer_class = SupportContractSerializer
+    filterset_class = SupportContractFilterSet
 
 
 class SupportContractAssignmentViewSet(NetBoxModelViewSet):
     queryset = SupportContractAssignment.objects.all()
     serializer_class = SupportContractAssignmentSerializer
+    filterset_class = SupportContractAssignmentFilterSet

--- a/netbox_lifecycle/api/views/hardware.py
+++ b/netbox_lifecycle/api/views/hardware.py
@@ -1,5 +1,6 @@
 from netbox.api.viewsets import NetBoxModelViewSet
 from netbox_lifecycle.api.serializers import HardwareLifecycleSerializer
+from netbox_lifecycle.filtersets import HardwareLifecycleFilterSet
 from netbox_lifecycle.models import HardwareLifecycle
 
 
@@ -11,3 +12,4 @@ __all__ = (
 class HardwareLifecycleViewSet(NetBoxModelViewSet):
     queryset = HardwareLifecycle.objects.all()
     serializer_class = HardwareLifecycleSerializer
+    filterset_class = HardwareLifecycleFilterSet

--- a/netbox_lifecycle/api/views/license.py
+++ b/netbox_lifecycle/api/views/license.py
@@ -1,6 +1,6 @@
 from netbox.api.viewsets import NetBoxModelViewSet
 from netbox_lifecycle.api.serializers import LicenseSerializer, LicenseAssignmentSerializer
-from netbox_lifecycle.filtersets import LicenseAssignmentFilterSet
+from netbox_lifecycle.filtersets import LicenseAssignmentFilterSet, LicenseFilterSet
 from netbox_lifecycle.models import License, LicenseAssignment
 
 
@@ -13,6 +13,7 @@ __all__ = (
 class LicenseViewSet(NetBoxModelViewSet):
     queryset = License.objects.all()
     serializer_class = LicenseSerializer
+    filterset_class = LicenseFilterSet
 
 
 class LicenseAssignmentViewSet(NetBoxModelViewSet):


### PR DESCRIPTION
### Fixes: #99 - Add missing FilterSets to the API ViewSets

* Add `VendorFilterSet` to `VendorViewSet` api
* Add `SupportSKUFilterSet` to `SupportSKUViewSet` api
* Add `SupportContractFilterSet` to `SupportContractViewSet` api
* Add `SupportContractAssignmentFilterSet` to `SupportContractAssignmentViewSet` api
* Add `HardwareLifecycleFilterSet` to `HardwareLifecycleViewSet` api
* Add `LicenseFilterSet` to `LicenseViewSet` api