### PR TITLE
Fixes: #81 - Add custom_fields support

### DIFF
--- a/netbox_lifecycle/api/_serializers/contract.py
+++ b/netbox_lifecycle/api/_serializers/contract.py
@@ -20,7 +20,7 @@ class SupportSKUSerializer(NetBoxModelSerializer):
 
     class Meta:
         model = SupportSKU
-        fields = ('url', 'id', 'display', 'manufacturer', 'sku', 'description', 'comments', )
+        fields = ('url', 'id', 'display', 'manufacturer', 'sku', 'description', 'comments', 'custom_fields', )
         brief_fields = ('url', 'id', 'display', 'manufacturer', 'sku', )
 
 
@@ -34,7 +34,7 @@ class SupportContractSerializer(NetBoxModelSerializer):
     class Meta:
         model = SupportContract
         fields = (
-            'url', 'id', 'display', 'vendor', 'contract_id', 'start', 'renewal', 'end', 'description', 'comments',
+            'url', 'id', 'display', 'vendor', 'contract_id', 'start', 'renewal', 'end', 'description', 'comments', 'custom_fields', 
         )
         brief_fields = ('url', 'id', 'display', 'vendor', 'contract_id', )
 
@@ -49,7 +49,7 @@ class SupportContractAssignmentSerializer(NetBoxModelSerializer):
     class Meta:
         model = SupportContractAssignment
         fields = (
-            'url', 'id', 'display', 'contract', 'sku', 'device', 'license', 'end', 'description', 'comments',
+            'url', 'id', 'display', 'contract', 'sku', 'device', 'license', 'end', 'description', 'comments', 'custom_fields', 
         )
 
         brief_fields = ('url', 'id', 'display', 'contract', 'sku', 'device', 'license', )

--- a/netbox_lifecycle/api/_serializers/contract.py
+++ b/netbox_lifecycle/api/_serializers/contract.py
@@ -15,7 +15,7 @@ __all__ = (
 
 
 class SupportSKUSerializer(NetBoxModelSerializer):
-    url = serializers.HyperlinkedIdentityField(view_name='plugins-api:netbox_lifecycle-api:hardwarelifecycle-detail')
+    url = serializers.HyperlinkedIdentityField(view_name='plugins-api:netbox_lifecycle-api:supportsku-detail')
     manufacturer = ManufacturerSerializer(nested=True)
 
     class Meta:
@@ -25,7 +25,7 @@ class SupportSKUSerializer(NetBoxModelSerializer):
 
 
 class SupportContractSerializer(NetBoxModelSerializer):
-    url = serializers.HyperlinkedIdentityField(view_name='plugins-api:netbox_lifecycle-api:hardwarelifecycle-detail')
+    url = serializers.HyperlinkedIdentityField(view_name='plugins-api:netbox_lifecycle-api:supportcontract-detail')
     vendor = VendorSerializer(nested=True)
     start = serializers.DateField(required=False)
     renewal = serializers.DateField(required=False)
@@ -40,7 +40,7 @@ class SupportContractSerializer(NetBoxModelSerializer):
 
 
 class SupportContractAssignmentSerializer(NetBoxModelSerializer):
-    url = serializers.HyperlinkedIdentityField(view_name='plugins-api:netbox_lifecycle-api:licenseassignment-detail')
+    url = serializers.HyperlinkedIdentityField(view_name='plugins-api:netbox_lifecycle-api:supportcontractassignment-detail')
     contract = SupportContractSerializer(nested=True)
     sku = SupportSKUSerializer(nested=True, required=False, allow_null=True)
     device = DeviceSerializer(nested=True, required=False, allow_null=True)

--- a/netbox_lifecycle/api/_serializers/hardware.py
+++ b/netbox_lifecycle/api/_serializers/hardware.py
@@ -31,7 +31,7 @@ class HardwareLifecycleSerializer(NetBoxModelSerializer):
         fields = (
             'url', 'id', 'display', 'assigned_object_type', 'assigned_object_id', 'end_of_sale',
             'end_of_maintenance', 'end_of_security', 'last_contract_attach', 'last_contract_renewal',
-            'end_of_support', 'notice', 'documentation', 'description', 'comments',
+            'end_of_support', 'notice', 'documentation', 'description', 'comments', 'custom_fields',
         )
         brief_fields = (
             'url', 'id', 'display', 'assigned_object_type', 'assigned_object_id', 'end_of_sale',

--- a/netbox_lifecycle/api/_serializers/license.py
+++ b/netbox_lifecycle/api/_serializers/license.py
@@ -18,7 +18,7 @@ class LicenseSerializer(NetBoxModelSerializer):
 
     class Meta:
         model = License
-        fields = ('url', 'id', 'display', 'name', 'manufacturer', 'description', 'comments', )
+        fields = ('url', 'id', 'display', 'name', 'manufacturer', 'description', 'comments', 'custom_fields', )
         brief_fields = ('url', 'id', 'display', 'name', )
 
 
@@ -30,5 +30,5 @@ class LicenseAssignmentSerializer(NetBoxModelSerializer):
 
     class Meta:
         model = LicenseAssignment
-        fields = ('url', 'id', 'display', 'vendor', 'license', 'device', 'description', 'comments', )
+        fields = ('url', 'id', 'display', 'vendor', 'license', 'device', 'description', 'comments', 'custom_fields', )
         brief_fields = ('url', 'id', 'display', 'vendor', 'license', 'device', )

--- a/netbox_lifecycle/api/_serializers/vendor.py
+++ b/netbox_lifecycle/api/_serializers/vendor.py
@@ -13,5 +13,5 @@ class VendorSerializer(NetBoxModelSerializer):
 
     class Meta:
         model = Vendor
-        fields = ('url', 'id', 'display', 'name', 'description', 'comments', )
+        fields = ('url', 'id', 'display', 'name', 'description', 'comments', 'custom_fields', )
         brief_fields = ('url', 'id', 'display', 'name', )

--- a/netbox_lifecycle/api/_serializers/vendor.py
+++ b/netbox_lifecycle/api/_serializers/vendor.py
@@ -9,7 +9,7 @@ __all__ = (
 
 
 class VendorSerializer(NetBoxModelSerializer):
-    url = serializers.HyperlinkedIdentityField(view_name='plugins-api:netbox_lifecycle-api:hardwarelifecycle-detail')
+    url = serializers.HyperlinkedIdentityField(view_name='plugins-api:netbox_lifecycle-api:vendor-detail')
 
     class Meta:
         model = Vendor


### PR DESCRIPTION
Hi !

This pull request fixes the following bugs : 

- Some objects URLs are wrong in the REST api : SupportSKU, SupportContract, SupportContractAssignment and Vendor objects are all returning self url as `/api/plugins/lifecycle/hardwarelifecycle/XXX/`
- Custom fields not returned from REST api (#81)

I'll stay available if you have questions.

Best regards,