### PR TITLE
Closes: #117 - Rename Nav Contracts to Support Contracts

### DIFF
--- a/netbox_lifecycle/forms/filtersets.py
+++ b/netbox_lifecycle/forms/filtersets.py
@@ -142,7 +142,7 @@ class SupportContractAssignmentFilterForm(NetBoxModelFilterSetForm):
         queryset=SupportContract.objects.all(),
         required=False,
         selector=True,
-        label=_('Contracts'),
+        label=_('Support Contracts'),
     )
     license_id = DynamicModelMultipleChoiceField(
         queryset=License.objects.all(),

--- a/netbox_lifecycle/navigation.py
+++ b/netbox_lifecycle/navigation.py
@@ -18,12 +18,12 @@ skus = PluginMenuItem(
 )
 contracts = PluginMenuItem(
     link='plugins:netbox_lifecycle:supportcontract_list',
-    link_text='Contracts',
+    link_text='Support Contracts',
     permissions=['netbox_lifecycle.view_supportcontract'],
 )
 contract_assignments = PluginMenuItem(
     link='plugins:netbox_lifecycle:supportcontractassignment_list',
-    link_text='Contract Assignments',
+    link_text='Support Assignments',
     permissions=['netbox_lifecycle.view_supportcontractassignment'],
 )
 licenses = PluginMenuItem(
@@ -42,7 +42,7 @@ menu = PluginMenu(
     label='Hardware Lifecycle',
     groups=(
         ('Lifecycle', (lifecycle,)),
-        ('Support Contracts', (vendors, skus, contracts, contract_assignments)),
+        ('Vendor Support', (vendors, skus, contracts, contract_assignments)),
         ('Licensing', (licenses, license_assignments)),
     ),
     icon_class='mdi mdi-server',


### PR DESCRIPTION
### Closes: #117 - Rename Nav Contracts to Support Contracts

* Rename Contracts to Support Contracts in navigation menu
* Rename Support Contracts to Vendor Support in navigation menu
* Rename Contracts on forms to Support Contracts (where appropriate)