### PR TITLE
Fixes #105: Add tags field to all REST API serializers

### DIFF
--- a/netbox_lifecycle/api/_serializers/contract.py
+++ b/netbox_lifecycle/api/_serializers/contract.py
@@ -34,6 +34,7 @@ class SupportSKUSerializer(NetBoxModelSerializer):
             'sku',
             'description',
             'comments',
+            'tags',
             'custom_fields',
         )
         brief_fields = (
@@ -67,6 +68,7 @@ class SupportContractSerializer(NetBoxModelSerializer):
             'end',
             'description',
             'comments',
+            'tags',
             'custom_fields',
         )
         brief_fields = (
@@ -100,6 +102,7 @@ class SupportContractAssignmentSerializer(NetBoxModelSerializer):
             'end',
             'description',
             'comments',
+            'tags',
             'custom_fields',
         )
 

--- a/netbox_lifecycle/api/_serializers/hardware.py
+++ b/netbox_lifecycle/api/_serializers/hardware.py
@@ -42,6 +42,7 @@ class HardwareLifecycleSerializer(NetBoxModelSerializer):
             'documentation',
             'description',
             'comments',
+            'tags',
             'custom_fields',
         )
         brief_fields = (

--- a/netbox_lifecycle/api/_serializers/license.py
+++ b/netbox_lifecycle/api/_serializers/license.py
@@ -28,6 +28,7 @@ class LicenseSerializer(NetBoxModelSerializer):
             'manufacturer',
             'description',
             'comments',
+            'tags',
             'custom_fields',
         )
         brief_fields = (
@@ -57,6 +58,7 @@ class LicenseAssignmentSerializer(NetBoxModelSerializer):
             'device',
             'description',
             'comments',
+            'tags',
             'custom_fields',
         )
         brief_fields = (

--- a/netbox_lifecycle/api/_serializers/vendor.py
+++ b/netbox_lifecycle/api/_serializers/vendor.py
@@ -20,6 +20,7 @@ class VendorSerializer(NetBoxModelSerializer):
             'name',
             'description',
             'comments',
+            'tags',
             'custom_fields',
         )
         brief_fields = (


### PR DESCRIPTION
## Summary

Add the missing `tags` field to all REST API serializers, enabling tag management via the API.

## Changes

Added `'tags'` to the `fields` tuple in:
- `VendorSerializer`
- `SupportSKUSerializer`
- `SupportContractSerializer`
- `SupportContractAssignmentSerializer`
- `HardwareLifecycleSerializer`
- `LicenseSerializer`
- `LicenseAssignmentSerializer`