### PR TITLE
Fixes #55: Add VirtualMachine support for License and Contract assignments

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ The Netbox Lifecycle plugin is a Hardware EOS/EOL, License and Support Contract 
 
 ## Features
 
-* Tracking EOL/EOS data
-* Tracking License
-* Tracking Support Contracts
+* Tracking EOL/EOS data for DeviceTypes and ModuleTypes
+* Tracking Licenses (assignable to Devices and Virtual Machines)
+* Tracking Support Contracts (assignable to Devices, Modules, and Virtual Machines)
 
 # Requirements
 
@@ -49,7 +49,7 @@ PLUGINS_CONFIG = {
 | Setting | Default | Description |
 |---------|---------|-------------|
 | `lifecycle_card_position` | `right_page` | Position of the Hardware Lifecycle Info card on Device, Module, DeviceType, and ModuleType detail pages. Options: `left_page`, `right_page`, `full_width_page`. |
-| `contract_card_position` | `right_page` | Position of the Support Contracts card on Device detail pages. Options: `left_page`, `right_page`, `full_width_page`. |
+| `contract_card_position` | `right_page` | Position of the Support Contracts card on Device and VirtualMachine detail pages. Options: `left_page`, `right_page`, `full_width_page`. |
 
 ### Hardware Lifecycle Info Card
 
@@ -57,7 +57,7 @@ Displays EOL/EOS information for the hardware type on Device, Module, DeviceType
 
 ### Support Contracts Card
 
-Displays all contract assignments on Device detail pages, grouped by status:
+Displays all contract assignments on Device and VirtualMachine detail pages, grouped by status:
 
 - **Active**: Contracts currently in effect
 - **Future**: Contracts with a start date in the future

--- a/netbox_lifecycle/api/_serializers/contract.py
+++ b/netbox_lifecycle/api/_serializers/contract.py
@@ -3,6 +3,7 @@ from rest_framework import serializers
 from dcim.api.serializers_.devices import DeviceSerializer, ModuleSerializer
 from dcim.api.serializers_.manufacturers import ManufacturerSerializer
 from netbox.api.serializers import NetBoxModelSerializer
+from virtualization.api.serializers_.virtualmachines import VirtualMachineSerializer
 from netbox_lifecycle.api._serializers.license import LicenseAssignmentSerializer
 from netbox_lifecycle.api._serializers.vendor import VendorSerializer
 from netbox_lifecycle.models import (
@@ -88,6 +89,9 @@ class SupportContractAssignmentSerializer(NetBoxModelSerializer):
     sku = SupportSKUSerializer(nested=True, required=False, allow_null=True)
     device = DeviceSerializer(nested=True, required=False, allow_null=True)
     module = ModuleSerializer(nested=True, required=False, allow_null=True)
+    virtual_machine = VirtualMachineSerializer(
+        nested=True, required=False, allow_null=True
+    )
     license = LicenseAssignmentSerializer(nested=True, required=False, allow_null=True)
 
     class Meta:
@@ -100,6 +104,7 @@ class SupportContractAssignmentSerializer(NetBoxModelSerializer):
             'sku',
             'device',
             'module',
+            'virtual_machine',
             'license',
             'end',
             'description',
@@ -116,5 +121,6 @@ class SupportContractAssignmentSerializer(NetBoxModelSerializer):
             'sku',
             'device',
             'module',
+            'virtual_machine',
             'license',
         )

--- a/netbox_lifecycle/api/_serializers/license.py
+++ b/netbox_lifecycle/api/_serializers/license.py
@@ -3,6 +3,7 @@ from rest_framework import serializers
 from dcim.api.serializers_.devices import DeviceSerializer
 from dcim.api.serializers_.manufacturers import ManufacturerSerializer
 from netbox.api.serializers import NetBoxModelSerializer
+from virtualization.api.serializers_.virtualmachines import VirtualMachineSerializer
 from netbox_lifecycle.api._serializers.vendor import VendorSerializer
 from netbox_lifecycle.models import License, LicenseAssignment
 
@@ -46,6 +47,9 @@ class LicenseAssignmentSerializer(NetBoxModelSerializer):
     license = LicenseSerializer(nested=True)
     vendor = VendorSerializer(nested=True)
     device = DeviceSerializer(nested=True, required=False, allow_null=True)
+    virtual_machine = VirtualMachineSerializer(
+        nested=True, required=False, allow_null=True
+    )
 
     class Meta:
         model = LicenseAssignment
@@ -56,6 +60,8 @@ class LicenseAssignmentSerializer(NetBoxModelSerializer):
             'vendor',
             'license',
             'device',
+            'virtual_machine',
+            'quantity',
             'description',
             'comments',
             'tags',
@@ -68,4 +74,5 @@ class LicenseAssignmentSerializer(NetBoxModelSerializer):
             'vendor',
             'license',
             'device',
+            'virtual_machine',
         )

--- a/netbox_lifecycle/filtersets/contract.py
+++ b/netbox_lifecycle/filtersets/contract.py
@@ -4,6 +4,7 @@ from django.utils.translation import gettext as _
 
 from dcim.models import Manufacturer, Device, Module
 from netbox.filtersets import NetBoxModelFilterSet
+from virtualization.models import VirtualMachine
 from netbox_lifecycle.models import (
     Vendor,
     SupportContract,
@@ -149,6 +150,17 @@ class SupportContractAssignmentFilterSet(NetBoxModelFilterSet):
         to_field_name='name',
         label=_('License (SKU)'),
     )
+    virtual_machine_id = django_filters.ModelMultipleChoiceFilter(
+        field_name='virtual_machine',
+        queryset=VirtualMachine.objects.all(),
+        label=_('Virtual Machine (ID)'),
+    )
+    virtual_machine = django_filters.ModelMultipleChoiceFilter(
+        field_name='virtual_machine__name',
+        queryset=VirtualMachine.objects.all(),
+        to_field_name='name',
+        label=_('Virtual Machine (name)'),
+    )
     device_status = django_filters.ModelMultipleChoiceFilter(
         field_name='device__status',
         queryset=Device.objects.all(),
@@ -173,7 +185,9 @@ class SupportContractAssignmentFilterSet(NetBoxModelFilterSet):
             | Q(device__name__icontains=value)
             | Q(module__serial__icontains=value)
             | Q(module__module_type__model__icontains=value)
+            | Q(virtual_machine__name__icontains=value)
             | Q(license__device__name__icontains=value)
+            | Q(license__virtual_machine__name__icontains=value)
             | Q(license__license__name__icontains=value)
         )
         return queryset.filter(qs_filter).distinct()

--- a/netbox_lifecycle/filtersets/license.py
+++ b/netbox_lifecycle/filtersets/license.py
@@ -4,6 +4,7 @@ from django.utils.translation import gettext as _
 
 from dcim.models import Manufacturer, Device
 from netbox.filtersets import NetBoxModelFilterSet
+from virtualization.models import VirtualMachine
 from netbox_lifecycle.models import Vendor, License, LicenseAssignment
 
 __all__ = (
@@ -74,6 +75,17 @@ class LicenseAssignmentFilterSet(NetBoxModelFilterSet):
         to_field_name='name',
         label=_('Device'),
     )
+    virtual_machine_id = django_filters.ModelMultipleChoiceFilter(
+        field_name='virtual_machine',
+        queryset=VirtualMachine.objects.all(),
+        label=_('Virtual Machine'),
+    )
+    virtual_machine = django_filters.ModelMultipleChoiceFilter(
+        field_name='virtual_machine__name',
+        queryset=VirtualMachine.objects.all(),
+        to_field_name='name',
+        label=_('Virtual Machine'),
+    )
 
     class Meta:
         model = LicenseAssignment
@@ -90,5 +102,6 @@ class LicenseAssignmentFilterSet(NetBoxModelFilterSet):
             | Q(license__name__icontains=value)
             | Q(vendor__name__icontains=value)
             | Q(device__name__icontains=value)
+            | Q(virtual_machine__name__icontains=value)
         )
         return queryset.filter(qs_filter).distinct()

--- a/netbox_lifecycle/forms/filtersets.py
+++ b/netbox_lifecycle/forms/filtersets.py
@@ -7,6 +7,7 @@ from django.forms import DateField
 from dcim.choices import DeviceStatusChoices
 from dcim.models import Device, Manufacturer, Module
 from netbox.forms import NetBoxModelFilterSetForm
+from virtualization.models import VirtualMachine
 from netbox_lifecycle.models import (
     HardwareLifecycle,
     SupportContract,
@@ -138,6 +139,7 @@ class SupportContractAssignmentFilterForm(NetBoxModelFilterSetForm):
             'contract_id',
             'device_id',
             'module_id',
+            'virtual_machine_id',
             'license_id',
             'device_status',
             name='Assignment',
@@ -166,6 +168,12 @@ class SupportContractAssignmentFilterForm(NetBoxModelFilterSetForm):
         required=False,
         label=_('Module'),
     )
+    virtual_machine_id = DynamicModelMultipleChoiceField(
+        queryset=VirtualMachine.objects.all(),
+        required=False,
+        selector=True,
+        label=_('Virtual Machines'),
+    )
     device_status = forms.MultipleChoiceField(
         label=_('Status'), choices=DeviceStatusChoices, required=False
     )
@@ -176,7 +184,13 @@ class LicenseAssignmentFilterForm(NetBoxModelFilterSetForm):
     model = LicenseAssignment
     fieldsets = (
         FieldSet('q', 'filter_id', 'tag'),
-        FieldSet('license_id', 'vendor_id', 'device_id', name='Assignment'),
+        FieldSet(
+            'license_id',
+            'vendor_id',
+            'device_id',
+            'virtual_machine_id',
+            name='Assignment',
+        ),
     )
     license_id = DynamicModelMultipleChoiceField(
         queryset=License.objects.all(),
@@ -195,5 +209,11 @@ class LicenseAssignmentFilterForm(NetBoxModelFilterSetForm):
         required=False,
         selector=True,
         label=_('Devices'),
+    )
+    virtual_machine_id = DynamicModelMultipleChoiceField(
+        queryset=VirtualMachine.objects.all(),
+        required=False,
+        selector=True,
+        label=_('Virtual Machines'),
     )
     tag = TagFilterField(model)

--- a/netbox_lifecycle/graphql/filters.py
+++ b/netbox_lifecycle/graphql/filters.py
@@ -59,6 +59,13 @@ class SupportContractAssignmentFilter(BaseObjectTypeFilterMixin):
         Annotated['DeviceFilter', strawberry.lazy('dcim.graphql.filters')] | None
     ) = strawberry_django.filter_field()
     device_id: strawberry.ID | None = strawberry_django.filter_field()
+    virtual_machine: (
+        Annotated[
+            'VirtualMachineFilter', strawberry.lazy('virtualization.graphql.filters')
+        ]
+        | None
+    ) = strawberry_django.filter_field()
+    virtual_machine_id: strawberry.ID | None = strawberry_django.filter_field()
     license: (
         Annotated['LicenseFilter', strawberry.lazy('netbox_lifecycle.graphql.filters')]
         | None
@@ -90,6 +97,13 @@ class LicenseAssignmentFilter(BaseObjectTypeFilterMixin):
         Annotated['DeviceFilter', strawberry.lazy('dcim.graphql.filters')] | None
     ) = strawberry_django.filter_field()
     device_id: strawberry.ID | None = strawberry_django.filter_field()
+    virtual_machine: (
+        Annotated[
+            'VirtualMachineFilter', strawberry.lazy('virtualization.graphql.filters')
+        ]
+        | None
+    ) = strawberry_django.filter_field()
+    virtual_machine_id: strawberry.ID | None = strawberry_django.filter_field()
 
 
 @strawberry_django.filter(models.HardwareLifecycle, lookups=True)

--- a/netbox_lifecycle/graphql/types.py
+++ b/netbox_lifecycle/graphql/types.py
@@ -10,6 +10,7 @@ from dcim.graphql.types import (
     ModuleTypeType,
     ModuleType,
 )
+from virtualization.graphql.types import VirtualMachineType
 from netbox.graphql.types import NetBoxObjectType
 from .filters import *
 
@@ -67,6 +68,7 @@ class SupportContractAssignmentType(NetBoxObjectType):
     sku: SupportSKUType | None
     device: DeviceType | None
     module: ModuleType | None
+    virtual_machine: VirtualMachineType | None
     license: LicenseType | None
     end: str | None
 
@@ -78,6 +80,7 @@ class LicenseAssignmentType(NetBoxObjectType):
     license: LicenseType
     vendor: VendorType
     device: DeviceType | None
+    virtual_machine: VirtualMachineType | None
     quantity: int | None
 
 

--- a/netbox_lifecycle/migrations/0016_add_virtual_machine_support.py
+++ b/netbox_lifecycle/migrations/0016_add_virtual_machine_support.py
@@ -1,0 +1,82 @@
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('virtualization', '0023_squashed_0036'),
+        ('netbox_lifecycle', '0015_supportcontractassignment_module'),
+    ]
+
+    operations = [
+        # Add virtual_machine to LicenseAssignment
+        migrations.AddField(
+            model_name='licenseassignment',
+            name='virtual_machine',
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name='licenses',
+                to='virtualization.virtualmachine',
+            ),
+        ),
+        # Add virtual_machine to SupportContractAssignment
+        migrations.AddField(
+            model_name='supportcontractassignment',
+            name='virtual_machine',
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name='contracts',
+                to='virtualization.virtualmachine',
+            ),
+        ),
+        # Update ordering for LicenseAssignment
+        migrations.AlterModelOptions(
+            name='licenseassignment',
+            options={'ordering': ['license', 'device', 'virtual_machine']},
+        ),
+        # Update ordering for SupportContractAssignment
+        migrations.AlterModelOptions(
+            name='supportcontractassignment',
+            options={
+                'ordering': [
+                    'contract',
+                    'device',
+                    'virtual_machine',
+                    'module',
+                    'license',
+                ]
+            },
+        ),
+        # Remove old constraint from LicenseAssignment if it exists
+        migrations.RemoveConstraint(
+            model_name='licenseassignment',
+            name='netbox_lifecycle_licenseassignment_unique_license_vendor_device',
+        ),
+        # Add check constraint for mutual exclusivity in LicenseAssignment
+        migrations.AddConstraint(
+            model_name='licenseassignment',
+            constraint=models.CheckConstraint(
+                check=models.Q(device__isnull=True, virtual_machine__isnull=False)
+                | models.Q(device__isnull=False, virtual_machine__isnull=True)
+                | models.Q(device__isnull=True, virtual_machine__isnull=True),
+                name='netbox_lifecycle_licenseassignment_device_vm_exclusive',
+                violation_error_message='Device and virtual machine are mutually exclusive.',
+            ),
+        ),
+        # Add check constraint for mutual exclusivity in SupportContractAssignment
+        migrations.AddConstraint(
+            model_name='supportcontractassignment',
+            constraint=models.CheckConstraint(
+                check=models.Q(device__isnull=True, virtual_machine__isnull=False)
+                | models.Q(device__isnull=False, virtual_machine__isnull=True)
+                | models.Q(device__isnull=True, virtual_machine__isnull=True),
+                name='netbox_lifecycle_supportcontractassignment_device_vm_exclusive',
+                violation_error_message='Device and virtual machine are mutually exclusive.',
+            ),
+        ),
+    ]

--- a/netbox_lifecycle/tables/contract.py
+++ b/netbox_lifecycle/tables/contract.py
@@ -121,6 +121,17 @@ class SupportContractAssignmentTable(NetBoxTable):
         accessor='module__serial',
         orderable=True,
     )
+    virtual_machine_name = tables.Column(
+        verbose_name=_('Virtual Machine'),
+        accessor='virtual_machine__name',
+        linkify=True,
+        orderable=True,
+    )
+    virtual_machine_status = ChoiceFieldColumn(
+        verbose_name=_('VM Status'),
+        accessor='virtual_machine__status',
+        orderable=True,
+    )
     license_name = tables.Column(
         verbose_name=_('License'),
         accessor='license__license__name',
@@ -150,11 +161,13 @@ class SupportContractAssignmentTable(NetBoxTable):
             'sku',
             'device_name',
             'module_name',
+            'virtual_machine_name',
             'license_name',
             'device_model',
             'device_serial',
             'module_serial',
             'device_status',
+            'virtual_machine_status',
             'quantity',
             'renewal',
             'end',
@@ -167,6 +180,7 @@ class SupportContractAssignmentTable(NetBoxTable):
             'sku',
             'device_name',
             'module_name',
+            'virtual_machine_name',
             'license_name',
             'device_model',
             'device_serial',

--- a/netbox_lifecycle/tables/license.py
+++ b/netbox_lifecycle/tables/license.py
@@ -36,6 +36,7 @@ class LicenseAssignmentTable(NetBoxTable):
     license = tables.Column(verbose_name=_('License'), linkify=True)
     vendor = tables.Column(verbose_name=_('Vendor'), linkify=True)
     device = tables.Column(verbose_name=_('Device'), linkify=True)
+    virtual_machine = tables.Column(verbose_name=_('Virtual Machine'), linkify=True)
 
     class Meta(NetBoxTable.Meta):
         model = LicenseAssignment
@@ -44,8 +45,9 @@ class LicenseAssignmentTable(NetBoxTable):
             'license',
             'vendor',
             'device',
+            'virtual_machine',
             'quantity',
             'description',
             'comments',
         )
-        default_columns = ('pk', 'license', 'vendor', 'device')
+        default_columns = ('pk', 'license', 'vendor', 'device', 'virtual_machine')

--- a/netbox_lifecycle/template_content.py
+++ b/netbox_lifecycle/template_content.py
@@ -114,9 +114,46 @@ class ModuleTypeLifecycleContent(BaseLifecycleContent):
     lifecycle_object_id_attr = 'id'
 
 
+class VirtualMachineContractContent(PluginTemplateExtension):
+    """Template extension for VirtualMachine detail pages showing contracts."""
+
+    models = ['virtualization.virtualmachine']
+
+    def get_contract_card_position(self):
+        return PLUGIN_SETTINGS.get('contract_card_position', 'right_page')
+
+    def _render_contract_card(self):
+        obj = self.context.get('object')
+        return self.render(
+            'netbox_lifecycle/inc/contract_card_placeholder.html',
+            extra_context={
+                'htmx_url': reverse(
+                    'plugins:netbox_lifecycle:virtualmachine_contracts_htmx',
+                    kwargs={'pk': obj.pk},
+                ),
+            },
+        )
+
+    def right_page(self):
+        if self.get_contract_card_position() == 'right_page':
+            return self._render_contract_card()
+        return ''
+
+    def left_page(self):
+        if self.get_contract_card_position() == 'left_page':
+            return self._render_contract_card()
+        return ''
+
+    def full_width_page(self):
+        if self.get_contract_card_position() == 'full_width_page':
+            return self._render_contract_card()
+        return ''
+
+
 template_extensions = (
     DeviceLifecycleContent,
     ModuleLifecycleContent,
     DeviceTypeLifecycleContent,
     ModuleTypeLifecycleContent,
+    VirtualMachineContractContent,
 )

--- a/netbox_lifecycle/templates/netbox_lifecycle/htmx/virtualmachine_contracts.html
+++ b/netbox_lifecycle/templates/netbox_lifecycle/htmx/virtualmachine_contracts.html
@@ -1,0 +1,130 @@
+{% load i18n %}
+{% load filters %}
+
+<div class="card">
+  <h5 class="card-header">{% trans "Support Contracts" %}</h5>
+  {% if active or future or unspecified or expired_count %}
+  <div class="card-body">
+    <ul class="nav nav-tabs" role="tablist">
+      {% if active %}
+      <li class="nav-item" role="presentation">
+        <a href="#tab-active" class="nav-link active" data-bs-toggle="tab" role="tab">
+          {% trans "Active" %} <span class="badge text-bg-success ms-1">{{ active|length }}</span>
+        </a>
+      </li>
+      {% endif %}
+      {% if future %}
+      <li class="nav-item" role="presentation">
+        <a href="#tab-future" class="nav-link {% if not active %}active{% endif %}" data-bs-toggle="tab" role="tab">
+          {% trans "Future" %} <span class="badge text-bg-info ms-1">{{ future|length }}</span>
+        </a>
+      </li>
+      {% endif %}
+      {% if unspecified %}
+      <li class="nav-item" role="presentation">
+        <a href="#tab-unspecified" class="nav-link {% if not active and not future %}active{% endif %}" data-bs-toggle="tab" role="tab">
+          {% trans "Unspecified" %} <span class="badge text-bg-secondary ms-1">{{ unspecified|length }}</span>
+        </a>
+      </li>
+      {% endif %}
+      {% if expired_count %}
+      <li class="nav-item" role="presentation">
+        <a href="#tab-expired" class="nav-link {% if not active and not future and not unspecified %}active{% endif %}" data-bs-toggle="tab" role="tab"
+           hx-get="{% url 'plugins:netbox_lifecycle:virtualmachine_contracts_expired' pk=virtual_machine.pk %}"
+           hx-trigger="click once"
+           hx-target="#tab-expired-content">
+          {% trans "Expired" %} <span class="badge text-bg-danger ms-1">{{ expired_count }}</span>
+        </a>
+      </li>
+      {% endif %}
+    </ul>
+    <div class="tab-content">
+      {% if active %}
+      <div class="tab-pane fade show active" id="tab-active" role="tabpanel">
+        <table class="table table-sm table-hover table-vcenter mb-0 mt-1">
+          <thead class="table-light">
+            <tr>
+              <th>{% trans "Contract" %}</th>
+              <th>{% trans "SKU" %}</th>
+              <th>{% trans "Vendor" %}</th>
+              <th class="text-end">{% trans "End Date" %}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for assignment in active %}
+            <tr>
+              <td><a href="{{ assignment.contract.get_absolute_url }}">{{ assignment.contract.contract_id }}</a></td>
+              <td>{% if assignment.sku %}<a href="{{ assignment.sku.get_absolute_url }}">{{ assignment.sku.sku }}</a>{% else %}-{% endif %}</td>
+              <td class="text-muted">{{ assignment.contract.vendor|default:"-" }}</td>
+              <td class="text-end">{{ assignment.end_date|date:"Y-m-d" }}</td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+      {% endif %}
+      {% if future %}
+      <div class="tab-pane fade {% if not active %}show active{% endif %}" id="tab-future" role="tabpanel">
+        <table class="table table-sm table-hover table-vcenter mb-0 mt-1">
+          <thead class="table-light">
+            <tr>
+              <th>{% trans "Contract" %}</th>
+              <th>{% trans "SKU" %}</th>
+              <th>{% trans "Vendor" %}</th>
+              <th class="text-end">{% trans "Starts" %}</th>
+              <th class="text-end">{% trans "Ends" %}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for assignment in future %}
+            <tr>
+              <td><a href="{{ assignment.contract.get_absolute_url }}">{{ assignment.contract.contract_id }}</a></td>
+              <td>{% if assignment.sku %}<a href="{{ assignment.sku.get_absolute_url }}">{{ assignment.sku.sku }}</a>{% else %}-{% endif %}</td>
+              <td class="text-muted">{{ assignment.contract.vendor|default:"-" }}</td>
+              <td class="text-end">{{ assignment.contract.start|date:"Y-m-d" }}</td>
+              <td class="text-end">{{ assignment.end_date|date:"Y-m-d" }}</td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+      {% endif %}
+      {% if unspecified %}
+      <div class="tab-pane fade {% if not active and not future %}show active{% endif %}" id="tab-unspecified" role="tabpanel">
+        <table class="table table-sm table-hover table-vcenter mb-0 mt-1">
+          <thead class="table-light">
+            <tr>
+              <th>{% trans "Contract" %}</th>
+              <th>{% trans "SKU" %}</th>
+              <th>{% trans "Vendor" %}</th>
+              <th class="text-end">{% trans "Started" %}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for assignment in unspecified %}
+            <tr>
+              <td><a href="{{ assignment.contract.get_absolute_url }}">{{ assignment.contract.contract_id }}</a></td>
+              <td>{% if assignment.sku %}<a href="{{ assignment.sku.get_absolute_url }}">{{ assignment.sku.sku }}</a>{% else %}-{% endif %}</td>
+              <td class="text-muted">{{ assignment.contract.vendor|default:"-" }}</td>
+              <td class="text-end">{{ assignment.contract.start|date:"Y-m-d"|default:"-" }}</td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+      {% endif %}
+      {% if expired_count %}
+      <div class="tab-pane fade {% if not active and not future and not unspecified %}show active{% endif %}" id="tab-expired" role="tabpanel">
+        <div id="tab-expired-content">
+          <div class="text-center py-3"><div class="spinner-border spinner-border-sm"></div></div>
+        </div>
+      </div>
+      {% endif %}
+    </div>
+  </div>
+  {% else %}
+  <div class="card-body">
+    <span class="text-muted">{% trans "None" %}</span>
+  </div>
+  {% endif %}
+</div>

--- a/netbox_lifecycle/urls.py
+++ b/netbox_lifecycle/urls.py
@@ -265,4 +265,14 @@ urlpatterns = [
         views.DeviceContractsExpiredHTMXView.as_view(),
         name='device_contracts_expired',
     ),
+    path(
+        'htmx/virtualmachine/<int:pk>/contracts/',
+        views.VirtualMachineContractsHTMXView.as_view(),
+        name='virtualmachine_contracts_htmx',
+    ),
+    path(
+        'htmx/virtualmachine/<int:pk>/contracts/expired/',
+        views.VirtualMachineContractsExpiredHTMXView.as_view(),
+        name='virtualmachine_contracts_expired',
+    ),
 ]

--- a/netbox_lifecycle/views/htmx.py
+++ b/netbox_lifecycle/views/htmx.py
@@ -3,6 +3,7 @@ from django.shortcuts import get_object_or_404, render
 from django.views import View
 
 from dcim.models import Device
+from virtualization.models import VirtualMachine
 
 from netbox_lifecycle.constants import (
     CONTRACT_STATUS_ACTIVE,
@@ -16,6 +17,8 @@ from netbox_lifecycle.models import SupportContractAssignment
 __all__ = (
     'DeviceContractsHTMXView',
     'DeviceContractsExpiredHTMXView',
+    'VirtualMachineContractsHTMXView',
+    'VirtualMachineContractsExpiredHTMXView',
 )
 
 
@@ -61,6 +64,63 @@ class DeviceContractsExpiredHTMXView(LoginRequiredMixin, View):
             a
             for a in SupportContractAssignment.objects.filter(
                 device=device
+            ).select_related(
+                'contract', 'contract__vendor', 'sku', 'sku__manufacturer', 'license'
+            )
+            if a.status == CONTRACT_STATUS_EXPIRED
+        ]
+
+        return render(
+            request,
+            'netbox_lifecycle/htmx/contract_list.html',
+            {
+                'assignments': expired,
+            },
+        )
+
+
+class VirtualMachineContractsHTMXView(LoginRequiredMixin, View):
+    """HTMX endpoint for virtual machine contract card content."""
+
+    def get(self, request, pk):
+        virtual_machine = get_object_or_404(VirtualMachine, pk=pk)
+        assignments = SupportContractAssignment.objects.filter(
+            virtual_machine=virtual_machine
+        ).select_related(
+            'contract', 'contract__vendor', 'sku', 'sku__manufacturer', 'license'
+        )
+
+        grouped = {
+            CONTRACT_STATUS_ACTIVE: [],
+            CONTRACT_STATUS_FUTURE: [],
+            CONTRACT_STATUS_UNSPECIFIED: [],
+            CONTRACT_STATUS_EXPIRED: [],
+        }
+        for assignment in assignments:
+            grouped[assignment.status].append(assignment)
+
+        return render(
+            request,
+            'netbox_lifecycle/htmx/virtualmachine_contracts.html',
+            {
+                'virtual_machine': virtual_machine,
+                'active': grouped[CONTRACT_STATUS_ACTIVE],
+                'future': grouped[CONTRACT_STATUS_FUTURE],
+                'unspecified': grouped[CONTRACT_STATUS_UNSPECIFIED],
+                'expired_count': len(grouped[CONTRACT_STATUS_EXPIRED]),
+            },
+        )
+
+
+class VirtualMachineContractsExpiredHTMXView(LoginRequiredMixin, View):
+    """HTMX endpoint for expired contracts only (virtual machine)."""
+
+    def get(self, request, pk):
+        virtual_machine = get_object_or_404(VirtualMachine, pk=pk)
+        expired = [
+            a
+            for a in SupportContractAssignment.objects.filter(
+                virtual_machine=virtual_machine
             ).select_related(
                 'contract', 'contract__vendor', 'sku', 'sku__manufacturer', 'license'
             )


### PR DESCRIPTION
## Summary

Adds `virtual_machine` ForeignKey to both `LicenseAssignment` and `SupportContractAssignment` models, allowing licenses and support contracts to be assigned to Virtual Machines in addition to Devices.

### Key Changes

- **Models**: Added `virtual_machine` field with mutual exclusivity constraint (device OR virtual_machine, not both)
- **Validation**: Module assignments restricted to devices only (VMs don't have modules)
- **Forms**: TabbedGroups UI for selecting Device vs Virtual Machine
- **Filtersets**: Added `virtual_machine` and `virtual_machine_id` filters
- **API**: Full serializer support with nested `VirtualMachineSerializer`
- **Tables**: Added virtual_machine columns to list views
- **Template Extension**: Support Contracts card now appears on VirtualMachine detail pages
- **HTMX Views**: Lazy-loading contract data for VM pages
- **Tests**: Comprehensive test coverage for VM functionality
- **README**: Updated to document VM support

### Database Migration

Migration `0016_add_virtual_machine_support.py` adds:
- `virtual_machine` ForeignKey to both models
- `CheckConstraint` enforcing device/VM mutual exclusivity

Closes #55