### PR TITLE
Fixes #133: Fix search index display_attrs referencing non-existent fields

### DIFF
--- a/netbox_lifecycle/search.py
+++ b/netbox_lifecycle/search.py
@@ -46,7 +46,7 @@ class SupportContractAssignmentIndex(SearchIndex):
         ('description', 4000),
         ('comments', 5000),
     )
-    display_attrs = ('vendor', 'start', 'renewal', 'end', 'description')
+    display_attrs = ('contract', 'sku', 'device', 'end', 'description')
 
 
 @register_search
@@ -70,4 +70,4 @@ class LicenseAssignmentIndex(SearchIndex):
         ('description', 4000),
         ('comments', 5000),
     )
-    display_attrs = ('manufacturer', 'description')
+    display_attrs = ('license', 'vendor', 'device', 'description')

--- a/netbox_lifecycle/tests/test_search.py
+++ b/netbox_lifecycle/tests/test_search.py
@@ -1,0 +1,52 @@
+from django.core.exceptions import FieldDoesNotExist
+from django.test import TestCase
+
+from netbox_lifecycle.search import (
+    SupportContractAssignmentIndex,
+    LicenseAssignmentIndex,
+)
+
+
+class SearchIndexDisplayAttrsTestCase(TestCase):
+    """
+    Test that search index display_attrs reference valid model fields.
+
+    Regression test for GitHub issue #133:
+    Search error "SupportContractAssignment has no field named 'vendor'"
+    """
+
+    def test_support_contract_assignment_display_attrs_are_valid_fields(self):
+        """
+        SupportContractAssignmentIndex.display_attrs should only reference
+        fields that exist on the SupportContractAssignment model.
+        """
+        index = SupportContractAssignmentIndex()
+        model = index.model
+
+        for attr in index.display_attrs:
+            # This should not raise FieldDoesNotExist
+            try:
+                model._meta.get_field(attr)
+            except FieldDoesNotExist:
+                self.fail(
+                    f"SupportContractAssignmentIndex.display_attrs references "
+                    f"non-existent field '{attr}' on {model.__name__}"
+                )
+
+    def test_license_assignment_display_attrs_are_valid_fields(self):
+        """
+        LicenseAssignmentIndex.display_attrs should only reference
+        fields that exist on the LicenseAssignment model.
+        """
+        index = LicenseAssignmentIndex()
+        model = index.model
+
+        for attr in index.display_attrs:
+            # This should not raise FieldDoesNotExist
+            try:
+                model._meta.get_field(attr)
+            except FieldDoesNotExist:
+                self.fail(
+                    f"LicenseAssignmentIndex.display_attrs references "
+                    f"non-existent field '{attr}' on {model.__name__}"
+                )


### PR DESCRIPTION
## Summary
- Fix SupportContractAssignmentIndex.display_attrs referencing fields from SupportContract instead of SupportContractAssignment
- Fix LicenseAssignmentIndex.display_attrs referencing fields from License instead of LicenseAssignment
- Add regression tests for display_attrs validation

## Test plan
- [x] New tests pass: `test_search.py`
- [x] Full test suite passes (392 tests)