### PR TITLE
Add clone_fields to HardwareLifecycle model

### DIFF
--- a/netbox_lifecycle/api/_serializers/hardware.py
+++ b/netbox_lifecycle/api/_serializers/hardware.py
@@ -5,7 +5,6 @@ from netbox.api.fields import ContentTypeField
 from netbox.api.serializers import NetBoxModelSerializer
 from netbox_lifecycle.models import HardwareLifecycle
 
-
 __all__ = ('HardwareLifecycleSerializer',)
 
 

--- a/netbox_lifecycle/api/views/contract.py
+++ b/netbox_lifecycle/api/views/contract.py
@@ -18,7 +18,6 @@ from netbox_lifecycle.models import (
     SupportSKU,
 )
 
-
 __all__ = (
     'VendorViewSet',
     'SupportSKUViewSet',

--- a/netbox_lifecycle/api/views/hardware.py
+++ b/netbox_lifecycle/api/views/hardware.py
@@ -3,7 +3,6 @@ from netbox_lifecycle.api.serializers import HardwareLifecycleSerializer
 from netbox_lifecycle.filtersets import HardwareLifecycleFilterSet
 from netbox_lifecycle.models import HardwareLifecycle
 
-
 __all__ = ('HardwareLifecycleViewSet',)
 
 

--- a/netbox_lifecycle/api/views/license.py
+++ b/netbox_lifecycle/api/views/license.py
@@ -6,7 +6,6 @@ from netbox_lifecycle.api.serializers import (
 from netbox_lifecycle.filtersets import LicenseAssignmentFilterSet, LicenseFilterSet
 from netbox_lifecycle.models import License, LicenseAssignment
 
-
 __all__ = ('LicenseViewSet', 'LicenseAssignmentViewSet')
 
 

--- a/netbox_lifecycle/filtersets/hardware.py
+++ b/netbox_lifecycle/filtersets/hardware.py
@@ -7,7 +7,6 @@ from dcim.models import ModuleType, DeviceType
 from netbox.filtersets import NetBoxModelFilterSet
 from netbox_lifecycle.models import HardwareLifecycle
 
-
 __all__ = ('HardwareLifecycleFilterSet',)
 
 

--- a/netbox_lifecycle/forms/filtersets.py
+++ b/netbox_lifecycle/forms/filtersets.py
@@ -24,7 +24,6 @@ from utilities.forms.fields import (
 from utilities.forms.rendering import FieldSet
 from utilities.forms.widgets import APISelectMultiple, DatePicker
 
-
 __all__ = (
     'HardwareLifecycleFilterForm',
     'SupportSKUFilterForm',

--- a/netbox_lifecycle/forms/model_forms.py
+++ b/netbox_lifecycle/forms/model_forms.py
@@ -19,7 +19,6 @@ from utilities.forms.fields import (
 from utilities.forms.rendering import FieldSet, TabbedGroups
 from utilities.forms.widgets import DatePicker
 
-
 __all__ = (
     'VendorForm',
     'SupportSKUForm',

--- a/netbox_lifecycle/graphql/filters.py
+++ b/netbox_lifecycle/graphql/filters.py
@@ -6,7 +6,6 @@ import strawberry_django
 from netbox.graphql.filters import PrimaryModelFilter
 from netbox_lifecycle import models
 
-
 __all__ = (
     'VendorFilter',
     'SupportSKUFilter',

--- a/netbox_lifecycle/models/contract.py
+++ b/netbox_lifecycle/models/contract.py
@@ -15,7 +15,6 @@ from netbox_lifecycle.constants import (
     CONTRACT_STATUS_UNSPECIFIED,
 )
 
-
 __all__ = (
     'Vendor',
     'SupportSKU',

--- a/netbox_lifecycle/models/hardware.py
+++ b/netbox_lifecycle/models/hardware.py
@@ -8,7 +8,6 @@ from netbox.models import PrimaryModel
 
 from netbox_lifecycle.constants import HARDWARE_LIFECYCLE_MODELS
 
-
 __all__ = ('HardwareLifecycle',)
 
 

--- a/netbox_lifecycle/models/license.py
+++ b/netbox_lifecycle/models/license.py
@@ -6,7 +6,6 @@ from django.utils.translation import gettext as _
 
 from netbox.models import PrimaryModel
 
-
 __all__ = ('License', 'LicenseAssignment')
 
 

--- a/netbox_lifecycle/tables/hardware.py
+++ b/netbox_lifecycle/tables/hardware.py
@@ -4,7 +4,6 @@ import django_tables2 as tables
 from netbox.tables import NetBoxTable
 from netbox_lifecycle.models import HardwareLifecycle
 
-
 __all__ = ('HardwareLifecycleTable',)
 
 

--- a/netbox_lifecycle/tables/license.py
+++ b/netbox_lifecycle/tables/license.py
@@ -4,7 +4,6 @@ import django_tables2 as tables
 from netbox.tables import NetBoxTable
 from netbox_lifecycle.models import License, LicenseAssignment
 
-
 __all__ = (
     'LicenseTable',
     'LicenseAssignmentTable',

--- a/netbox_lifecycle/tests/test_htmx_views.py
+++ b/netbox_lifecycle/tests/test_htmx_views.py
@@ -15,7 +15,6 @@ from netbox_lifecycle.models import (
     Vendor,
 )
 
-
 User = get_user_model()
 
 

--- a/netbox_lifecycle/views/contract.py
+++ b/netbox_lifecycle/views/contract.py
@@ -41,7 +41,6 @@ from netbox_lifecycle.tables import (
 )
 from utilities.views import ViewTab, register_model_view, GetRelatedModelsMixin
 
-
 __all__ = (
     # Vendor
     'VendorListView',

--- a/netbox_lifecycle/views/hardware.py
+++ b/netbox_lifecycle/views/hardware.py
@@ -16,7 +16,6 @@ from netbox_lifecycle.models import HardwareLifecycle
 from netbox_lifecycle.tables import HardwareLifecycleTable
 from utilities.views import register_model_view
 
-
 __all__ = (
     'HardwareLifecycleListView',
     'HardwareLifecycleView',

--- a/netbox_lifecycle/views/htmx.py
+++ b/netbox_lifecycle/views/htmx.py
@@ -13,7 +13,6 @@ from netbox_lifecycle.constants import (
 )
 from netbox_lifecycle.models import SupportContractAssignment
 
-
 __all__ = (
     'DeviceContractsHTMXView',
     'DeviceContractsExpiredHTMXView',

--- a/netbox_lifecycle/views/license.py
+++ b/netbox_lifecycle/views/license.py
@@ -20,7 +20,6 @@ from netbox_lifecycle.models import License, LicenseAssignment
 from netbox_lifecycle.tables import LicenseTable, LicenseAssignmentTable
 from utilities.views import ViewTab, register_model_view
 
-
 __all__ = (
     'LicenseListView',
     'LicenseView',


### PR DESCRIPTION
## Summary
- Add `clone_fields` to `HardwareLifecycle` model to enable NetBox's built-in Clone feature
- Users can now clone lifecycle entries and only change the device/module type, making it easier to add lifecycle data for similar hardware


Closes #137

I also ran Black against everything. Not related to my changes but helpful nonetheless