### PR TITLE
Add Licenses card to Device and VM detail pages

### DIFF
--- a/netbox_lifecycle/__init__.py
+++ b/netbox_lifecycle/__init__.py
@@ -18,6 +18,7 @@ class NetBoxLifeCycle(PluginConfig):
     default_settings = {
         'lifecycle_card_position': 'right_page',
         'contract_card_position': 'right_page',
+        'license_card_position': 'right_page',
     }
     queues = []
     graphql_schema = 'graphql.schema.schema'

--- a/netbox_lifecycle/template_content.py
+++ b/netbox_lifecycle/template_content.py
@@ -4,6 +4,7 @@ from django.urls import reverse
 from netbox.plugins import PluginTemplateExtension
 
 from .models import hardware
+from .models.license import LicenseAssignment
 
 PLUGIN_SETTINGS = settings.PLUGINS_CONFIG.get('netbox_lifecycle', {})
 
@@ -58,6 +59,9 @@ class DeviceLifecycleContent(BaseLifecycleContent):
     def get_contract_card_position(self):
         return PLUGIN_SETTINGS.get('contract_card_position', 'right_page')
 
+    def get_license_card_position(self):
+        return PLUGIN_SETTINGS.get('license_card_position', 'right_page')
+
     def _render_contract_card(self):
         obj = self.context.get('object')
         return self.render(
@@ -70,12 +74,28 @@ class DeviceLifecycleContent(BaseLifecycleContent):
             },
         )
 
+    def _render_license_card(self):
+        obj = self.context.get('object')
+        if not LicenseAssignment.objects.filter(device=obj).exists():
+            return ''
+        return self.render(
+            'netbox_lifecycle/inc/license_card_placeholder.html',
+            extra_context={
+                'htmx_url': reverse(
+                    'plugins:netbox_lifecycle:device_licenses_htmx',
+                    kwargs={'pk': obj.pk},
+                ),
+            },
+        )
+
     def right_page(self):
         result = ''
         if self.get_lifecycle_card_position() == 'right_page':
             result += self._render_lifecycle_info()
         if self.get_contract_card_position() == 'right_page':
             result += self._render_contract_card()
+        if self.get_license_card_position() == 'right_page':
+            result += self._render_license_card()
         return result
 
     def left_page(self):
@@ -84,6 +104,8 @@ class DeviceLifecycleContent(BaseLifecycleContent):
             result += self._render_lifecycle_info()
         if self.get_contract_card_position() == 'left_page':
             result += self._render_contract_card()
+        if self.get_license_card_position() == 'left_page':
+            result += self._render_license_card()
         return result
 
     def full_width_page(self):
@@ -92,6 +114,8 @@ class DeviceLifecycleContent(BaseLifecycleContent):
             result += self._render_lifecycle_info()
         if self.get_contract_card_position() == 'full_width_page':
             result += self._render_contract_card()
+        if self.get_license_card_position() == 'full_width_page':
+            result += self._render_license_card()
         return result
 
 
@@ -114,12 +138,15 @@ class ModuleTypeLifecycleContent(BaseLifecycleContent):
 
 
 class VirtualMachineContractContent(PluginTemplateExtension):
-    """Template extension for VirtualMachine detail pages showing contracts."""
+    """Template extension for VirtualMachine detail pages showing contracts and licenses."""
 
     models = ['virtualization.virtualmachine']
 
     def get_contract_card_position(self):
         return PLUGIN_SETTINGS.get('contract_card_position', 'right_page')
+
+    def get_license_card_position(self):
+        return PLUGIN_SETTINGS.get('license_card_position', 'right_page')
 
     def _render_contract_card(self):
         obj = self.context.get('object')
@@ -133,20 +160,43 @@ class VirtualMachineContractContent(PluginTemplateExtension):
             },
         )
 
+    def _render_license_card(self):
+        obj = self.context.get('object')
+        if not LicenseAssignment.objects.filter(virtual_machine=obj).exists():
+            return ''
+        return self.render(
+            'netbox_lifecycle/inc/license_card_placeholder.html',
+            extra_context={
+                'htmx_url': reverse(
+                    'plugins:netbox_lifecycle:virtualmachine_licenses_htmx',
+                    kwargs={'pk': obj.pk},
+                ),
+            },
+        )
+
     def right_page(self):
+        result = ''
         if self.get_contract_card_position() == 'right_page':
-            return self._render_contract_card()
-        return ''
+            result += self._render_contract_card()
+        if self.get_license_card_position() == 'right_page':
+            result += self._render_license_card()
+        return result
 
     def left_page(self):
+        result = ''
         if self.get_contract_card_position() == 'left_page':
-            return self._render_contract_card()
-        return ''
+            result += self._render_contract_card()
+        if self.get_license_card_position() == 'left_page':
+            result += self._render_license_card()
+        return result
 
     def full_width_page(self):
+        result = ''
         if self.get_contract_card_position() == 'full_width_page':
-            return self._render_contract_card()
-        return ''
+            result += self._render_contract_card()
+        if self.get_license_card_position() == 'full_width_page':
+            result += self._render_license_card()
+        return result
 
 
 template_extensions = (

--- a/netbox_lifecycle/templates/netbox_lifecycle/htmx/device_licenses.html
+++ b/netbox_lifecycle/templates/netbox_lifecycle/htmx/device_licenses.html
@@ -1,0 +1,47 @@
+{% load i18n %}
+
+<div class="card">
+  <h5 class="card-header">
+    {% trans "Licenses" %}
+    <div class="card-actions">
+      <a href="{% url 'plugins:netbox_lifecycle:licenseassignment_add' %}?device={{ device.pk }}&return_url={{ device.get_absolute_url }}" class="btn btn-ghost-primary btn-sm">
+        <span class="mdi mdi-plus-thick" aria-hidden="true"></span> {% trans "Assign License" %}
+      </a>
+    </div>
+  </h5>
+  {% if assignments %}
+  <div class="card-body">
+    <table class="table table-sm table-hover table-vcenter mb-0">
+      <thead class="table-light">
+        <tr>
+          <th>{% trans "License" %}</th>
+          <th>{% trans "Manufacturer" %}</th>
+          <th>{% trans "Vendor" %}</th>
+          <th>{% trans "Quantity" %}</th>
+          <th>{% trans "Description" %}</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for assignment in assignments %}
+        <tr>
+          <td><a href="{{ assignment.license.get_absolute_url }}">{{ assignment.license.name }}</a></td>
+          <td class="text-muted">{{ assignment.license.manufacturer|default:"-" }}</td>
+          <td class="text-muted">{{ assignment.vendor|default:"-" }}</td>
+          <td>{{ assignment.quantity|default:"-" }}</td>
+          <td class="text-muted">{{ assignment.description|default:"-" }}</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+    {% if show_all_url %}
+    <div class="text-end mt-2">
+      <small class="text-muted"><a href="{{ show_all_url }}">{% trans "Show all Licenses" %}</a></small>
+    </div>
+    {% endif %}
+  </div>
+  {% else %}
+  <div class="card-body">
+    <span class="text-muted">{% trans "None" %}</span>
+  </div>
+  {% endif %}
+</div>

--- a/netbox_lifecycle/templates/netbox_lifecycle/htmx/virtualmachine_licenses.html
+++ b/netbox_lifecycle/templates/netbox_lifecycle/htmx/virtualmachine_licenses.html
@@ -1,0 +1,47 @@
+{% load i18n %}
+
+<div class="card">
+  <h5 class="card-header">
+    {% trans "Licenses" %}
+    <div class="card-actions">
+      <a href="{% url 'plugins:netbox_lifecycle:licenseassignment_add' %}?virtual_machine={{ virtual_machine.pk }}&return_url={{ virtual_machine.get_absolute_url }}" class="btn btn-ghost-primary btn-sm">
+        <span class="mdi mdi-plus-thick" aria-hidden="true"></span> {% trans "Assign License" %}
+      </a>
+    </div>
+  </h5>
+  {% if assignments %}
+  <div class="card-body">
+    <table class="table table-sm table-hover table-vcenter mb-0">
+      <thead class="table-light">
+        <tr>
+          <th>{% trans "License" %}</th>
+          <th>{% trans "Manufacturer" %}</th>
+          <th>{% trans "Vendor" %}</th>
+          <th>{% trans "Quantity" %}</th>
+          <th>{% trans "Description" %}</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for assignment in assignments %}
+        <tr>
+          <td><a href="{{ assignment.license.get_absolute_url }}">{{ assignment.license.name }}</a></td>
+          <td class="text-muted">{{ assignment.license.manufacturer|default:"-" }}</td>
+          <td class="text-muted">{{ assignment.vendor|default:"-" }}</td>
+          <td>{{ assignment.quantity|default:"-" }}</td>
+          <td class="text-muted">{{ assignment.description|default:"-" }}</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+    {% if show_all_url %}
+    <div class="text-end mt-2">
+      <small class="text-muted"><a href="{{ show_all_url }}">{% trans "Show all Licenses" %}</a></small>
+    </div>
+    {% endif %}
+  </div>
+  {% else %}
+  <div class="card-body">
+    <span class="text-muted">{% trans "None" %}</span>
+  </div>
+  {% endif %}
+</div>

--- a/netbox_lifecycle/templates/netbox_lifecycle/inc/license_card_placeholder.html
+++ b/netbox_lifecycle/templates/netbox_lifecycle/inc/license_card_placeholder.html
@@ -1,0 +1,12 @@
+{% load i18n %}
+
+<div hx-get="{{ htmx_url }}"
+     hx-trigger="load"
+     hx-swap="outerHTML">
+  <div class="card">
+    <h5 class="card-header">{% trans "Licenses" %}</h5>
+    <div class="card-body text-center">
+      <div class="spinner-border spinner-border-sm"></div>
+    </div>
+  </div>
+</div>

--- a/netbox_lifecycle/tests/test_htmx_views.py
+++ b/netbox_lifecycle/tests/test_htmx_views.py
@@ -4,6 +4,7 @@ from dcim.models import Device, DeviceRole, DeviceType, Manufacturer, Site
 from django.contrib.auth import get_user_model
 from django.test import TestCase
 from django.urls import reverse
+from virtualization.models import Cluster, ClusterType, VirtualMachine
 
 from netbox_lifecycle.models import (
     License,
@@ -13,6 +14,7 @@ from netbox_lifecycle.models import (
     SupportSKU,
     Vendor,
 )
+from netbox_lifecycle.views.htmx import MAX_LICENSE_DISPLAY
 
 User = get_user_model()
 
@@ -279,3 +281,231 @@ class DeviceContractsHTMXViewTest(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'EXPIRED-SKU-001')
         self.assertContains(response, 'SKU-EXPIRED-SUPPORT')
+
+
+class DeviceLicensesHTMXViewTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.manufacturer = Manufacturer.objects.create(
+            name='License Manufacturer', slug='license-manufacturer'
+        )
+        device_type = DeviceType.objects.create(
+            manufacturer=cls.manufacturer, model='License Model', slug='license-model'
+        )
+        device_role = DeviceRole.objects.create(
+            name='License Role', slug='license-role'
+        )
+        site = Site.objects.create(name='License Site', slug='license-site')
+        cls.device = Device.objects.create(
+            name='License Device',
+            device_type=device_type,
+            role=device_role,
+            site=site,
+        )
+        cls.vendor = Vendor.objects.create(name='License Vendor')
+        cls.license = License.objects.create(
+            manufacturer=cls.manufacturer,
+            name='Test License',
+        )
+        cls.user = User.objects.create_user(username='licenseuser', password='testpass')
+
+    def test_device_licenses_requires_login(self):
+        url = reverse(
+            'plugins:netbox_lifecycle:device_licenses_htmx',
+            kwargs={'pk': self.device.pk},
+        )
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 302)
+
+    def test_device_licenses_empty(self):
+        self.client.force_login(self.user)
+        url = reverse(
+            'plugins:netbox_lifecycle:device_licenses_htmx',
+            kwargs={'pk': self.device.pk},
+        )
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'None')
+
+    def test_device_licenses_with_assignment(self):
+        LicenseAssignment.objects.create(
+            license=self.license,
+            vendor=self.vendor,
+            device=self.device,
+            quantity=5,
+        )
+
+        self.client.force_login(self.user)
+        url = reverse(
+            'plugins:netbox_lifecycle:device_licenses_htmx',
+            kwargs={'pk': self.device.pk},
+        )
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'Test License')
+        self.assertContains(response, 'License Manufacturer')
+        self.assertContains(response, 'License Vendor')
+        self.assertContains(response, '5')
+
+    def test_device_licenses_assign_button(self):
+        LicenseAssignment.objects.create(
+            license=self.license,
+            vendor=self.vendor,
+            device=self.device,
+        )
+
+        self.client.force_login(self.user)
+        url = reverse(
+            'plugins:netbox_lifecycle:device_licenses_htmx',
+            kwargs={'pk': self.device.pk},
+        )
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'Assign License')
+        self.assertContains(response, f'device={self.device.pk}')
+
+    def test_device_licenses_show_all_link(self):
+        for i in range(MAX_LICENSE_DISPLAY + 1):
+            lic = License.objects.create(
+                manufacturer=self.manufacturer,
+                name=f'Bulk License {i}',
+            )
+            LicenseAssignment.objects.create(
+                license=lic,
+                vendor=self.vendor,
+                device=self.device,
+            )
+
+        self.client.force_login(self.user)
+        url = reverse(
+            'plugins:netbox_lifecycle:device_licenses_htmx',
+            kwargs={'pk': self.device.pk},
+        )
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'Show all Licenses')
+
+    def test_device_licenses_no_show_all_when_under_limit(self):
+        LicenseAssignment.objects.create(
+            license=self.license,
+            vendor=self.vendor,
+            device=self.device,
+        )
+
+        self.client.force_login(self.user)
+        url = reverse(
+            'plugins:netbox_lifecycle:device_licenses_htmx',
+            kwargs={'pk': self.device.pk},
+        )
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, 'Show all Licenses')
+
+
+class VirtualMachineLicensesHTMXViewTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.manufacturer = Manufacturer.objects.create(
+            name='VM License Mfg', slug='vm-license-mfg'
+        )
+        cluster_type = ClusterType.objects.create(
+            name='VM Cluster Type', slug='vm-cluster-type'
+        )
+        cluster = Cluster.objects.create(name='VM Cluster', type=cluster_type)
+        cls.virtual_machine = VirtualMachine.objects.create(
+            name='License VM',
+            cluster=cluster,
+        )
+        cls.vendor = Vendor.objects.create(name='VM License Vendor')
+        cls.license = License.objects.create(
+            manufacturer=cls.manufacturer,
+            name='VM Test License',
+        )
+        cls.user = User.objects.create_user(
+            username='vmlicenseuser', password='testpass'
+        )
+
+    def test_vm_licenses_requires_login(self):
+        url = reverse(
+            'plugins:netbox_lifecycle:virtualmachine_licenses_htmx',
+            kwargs={'pk': self.virtual_machine.pk},
+        )
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 302)
+
+    def test_vm_licenses_empty(self):
+        self.client.force_login(self.user)
+        url = reverse(
+            'plugins:netbox_lifecycle:virtualmachine_licenses_htmx',
+            kwargs={'pk': self.virtual_machine.pk},
+        )
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'None')
+
+    def test_vm_licenses_with_assignment(self):
+        LicenseAssignment.objects.create(
+            license=self.license,
+            vendor=self.vendor,
+            virtual_machine=self.virtual_machine,
+            quantity=10,
+        )
+
+        self.client.force_login(self.user)
+        url = reverse(
+            'plugins:netbox_lifecycle:virtualmachine_licenses_htmx',
+            kwargs={'pk': self.virtual_machine.pk},
+        )
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'VM Test License')
+        self.assertContains(response, 'VM License Mfg')
+        self.assertContains(response, 'VM License Vendor')
+        self.assertContains(response, '10')
+
+    def test_vm_licenses_assign_button(self):
+        LicenseAssignment.objects.create(
+            license=self.license,
+            vendor=self.vendor,
+            virtual_machine=self.virtual_machine,
+        )
+
+        self.client.force_login(self.user)
+        url = reverse(
+            'plugins:netbox_lifecycle:virtualmachine_licenses_htmx',
+            kwargs={'pk': self.virtual_machine.pk},
+        )
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'Assign License')
+        self.assertContains(response, f'virtual_machine={self.virtual_machine.pk}')
+
+    def test_vm_licenses_show_all_link(self):
+        for i in range(MAX_LICENSE_DISPLAY + 1):
+            lic = License.objects.create(
+                manufacturer=self.manufacturer,
+                name=f'VM Bulk License {i}',
+            )
+            LicenseAssignment.objects.create(
+                license=lic,
+                vendor=self.vendor,
+                virtual_machine=self.virtual_machine,
+            )
+
+        self.client.force_login(self.user)
+        url = reverse(
+            'plugins:netbox_lifecycle:virtualmachine_licenses_htmx',
+            kwargs={'pk': self.virtual_machine.pk},
+        )
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'Show all Licenses')

--- a/netbox_lifecycle/urls.py
+++ b/netbox_lifecycle/urls.py
@@ -275,4 +275,14 @@ urlpatterns = [
         views.VirtualMachineContractsExpiredHTMXView.as_view(),
         name='virtualmachine_contracts_expired',
     ),
+    path(
+        'htmx/device/<int:pk>/licenses/',
+        views.DeviceLicensesHTMXView.as_view(),
+        name='device_licenses_htmx',
+    ),
+    path(
+        'htmx/virtualmachine/<int:pk>/licenses/',
+        views.VirtualMachineLicensesHTMXView.as_view(),
+        name='virtualmachine_licenses_htmx',
+    ),
 ]

--- a/netbox_lifecycle/views/htmx.py
+++ b/netbox_lifecycle/views/htmx.py
@@ -10,13 +10,17 @@ from netbox_lifecycle.constants import (
     CONTRACT_STATUS_FUTURE,
     CONTRACT_STATUS_UNSPECIFIED,
 )
-from netbox_lifecycle.models import SupportContractAssignment
+from netbox_lifecycle.models import LicenseAssignment, SupportContractAssignment
+
+MAX_LICENSE_DISPLAY = 10
 
 __all__ = (
     'DeviceContractsExpiredHTMXView',
     'DeviceContractsHTMXView',
+    'DeviceLicensesHTMXView',
     'VirtualMachineContractsExpiredHTMXView',
     'VirtualMachineContractsHTMXView',
+    'VirtualMachineLicensesHTMXView',
 )
 
 
@@ -106,6 +110,60 @@ class VirtualMachineContractsHTMXView(LoginRequiredMixin, View):
                 'future': grouped[CONTRACT_STATUS_FUTURE],
                 'unspecified': grouped[CONTRACT_STATUS_UNSPECIFIED],
                 'expired_count': len(grouped[CONTRACT_STATUS_EXPIRED]),
+            },
+        )
+
+
+class DeviceLicensesHTMXView(LoginRequiredMixin, View):
+    """HTMX endpoint for device license card content."""
+
+    def get(self, request, pk):
+        device = get_object_or_404(Device, pk=pk)
+        assignments = LicenseAssignment.objects.filter(device=device).select_related(
+            'license', 'license__manufacturer', 'vendor'
+        )
+
+        total_count = assignments.count()
+        show_all_url = None
+        if total_count > MAX_LICENSE_DISPLAY:
+            show_all_url = (
+                f'/plugins/lifecycle/license-assignment/?device_id={device.pk}'
+            )
+            assignments = assignments[:MAX_LICENSE_DISPLAY]
+
+        return render(
+            request,
+            'netbox_lifecycle/htmx/device_licenses.html',
+            {
+                'device': device,
+                'assignments': assignments,
+                'show_all_url': show_all_url,
+            },
+        )
+
+
+class VirtualMachineLicensesHTMXView(LoginRequiredMixin, View):
+    """HTMX endpoint for virtual machine license card content."""
+
+    def get(self, request, pk):
+        virtual_machine = get_object_or_404(VirtualMachine, pk=pk)
+        assignments = LicenseAssignment.objects.filter(
+            virtual_machine=virtual_machine
+        ).select_related('license', 'license__manufacturer', 'vendor')
+
+        total_count = assignments.count()
+        show_all_url = None
+        if total_count > MAX_LICENSE_DISPLAY:
+            show_all_url = f'/plugins/lifecycle/license-assignment/?virtual_machine_id={virtual_machine.pk}'
+            assignments = assignments[:MAX_LICENSE_DISPLAY]
+
+        return render(
+            request,
+            'netbox_lifecycle/htmx/virtualmachine_licenses.html',
+            {
+                'virtual_machine': virtual_machine,
+                'assignments': assignments,
+                'show_all_url': show_all_url,
             },
         )
 


### PR DESCRIPTION
## Summary
- Add Licenses card to Device and Virtual Machine detail pages
- Card only renders when the device/VM has license assignments
- "Assign License" button in card header pre-fills the device/VM
- "Show all Licenses" link appears when more than 10 assignments exist
- New `license_card_position` setting (defaults to `right_page`)

Closes #86

## Tests
- [x] HTMX views require authentication
- [x] Card hidden when no license assignments exist
- [x] Assignments display License, Manufacturer, Vendor, Quantity
- [x] "Assign License" button links with device/VM prefilled
- [x] "Show all" link appears only when >10 assignments
- [x] Both Device and VM views covered