### PR TITLE
Fixes: #149 - Change `check` in favour of `condition` in CheckConstraint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
     - name: Check Black
       uses: psf/black@stable
       with:
-        options: "--check --skip-string-normalization"
+        options: "--check --skip-string-normalization --fast"
         src: "netbox-lifecycle/netbox_lifecycle"
 
     - name: Run tests

--- a/netbox_lifecycle/migrations/0016_add_virtual_machine_support.py
+++ b/netbox_lifecycle/migrations/0016_add_virtual_machine_support.py
@@ -61,7 +61,7 @@ class Migration(migrations.Migration):
         migrations.AddConstraint(
             model_name='licenseassignment',
             constraint=models.CheckConstraint(
-                check=models.Q(device__isnull=True, virtual_machine__isnull=False)
+                condition=models.Q(device__isnull=True, virtual_machine__isnull=False)
                 | models.Q(device__isnull=False, virtual_machine__isnull=True)
                 | models.Q(device__isnull=True, virtual_machine__isnull=True),
                 name='netbox_lifecycle_licenseassignment_device_vm_exclusive',
@@ -72,7 +72,7 @@ class Migration(migrations.Migration):
         migrations.AddConstraint(
             model_name='supportcontractassignment',
             constraint=models.CheckConstraint(
-                check=models.Q(device__isnull=True, virtual_machine__isnull=False)
+                condition=models.Q(device__isnull=True, virtual_machine__isnull=False)
                 | models.Q(device__isnull=False, virtual_machine__isnull=True)
                 | models.Q(device__isnull=True, virtual_machine__isnull=True),
                 name='netbox_lifecycle_supportcontractassignment_device_vm_exclusive',

--- a/netbox_lifecycle/models/contract.py
+++ b/netbox_lifecycle/models/contract.py
@@ -177,7 +177,7 @@ class SupportContractAssignment(PrimaryModel):
         ordering = ['contract', 'device', 'virtual_machine', 'module', 'license']
         constraints = (
             models.CheckConstraint(
-                check=(
+                condition=(
                     models.Q(device__isnull=True, virtual_machine__isnull=False)
                     | models.Q(device__isnull=False, virtual_machine__isnull=True)
                     | models.Q(device__isnull=True, virtual_machine__isnull=True)

--- a/netbox_lifecycle/models/license.py
+++ b/netbox_lifecycle/models/license.py
@@ -82,7 +82,7 @@ class LicenseAssignment(PrimaryModel):
         ordering = ['license', 'device', 'virtual_machine']
         constraints = (
             models.CheckConstraint(
-                check=(
+                condition=(
                     models.Q(device__isnull=True, virtual_machine__isnull=False)
                     | models.Q(device__isnull=False, virtual_machine__isnull=True)
                     | models.Q(device__isnull=True, virtual_machine__isnull=True)

--- a/netbox_lifecycle/search.py
+++ b/netbox_lifecycle/search.py
@@ -58,7 +58,7 @@ class LicenseIndex(SearchIndex):
         ('description', 4000),
         ('comments', 5000),
     )
-    display_attrs = ('description', )
+    display_attrs = ('description',)
 
 
 @register_search


### PR DESCRIPTION
### Fixes: #149 - Change `check` in favour of `condition` in CheckConstraint

In DJango 6.x, `check` was removed in favour of `condition` in CheckConstraint due to deprecation in 5.1

* Adjust all `check` arguments in favour of `condition`