### PR TITLE
Fixes: #151 - Remove edit and delete actions from SupportContractAssignmentListView

### DIFF
--- a/netbox_lifecycle/views/contract.py
+++ b/netbox_lifecycle/views/contract.py
@@ -259,8 +259,6 @@ class SupportContractAssignmentListView(ObjectListView):
     actions = {
         'add': {'add'},
         'export': {'view'},
-        'edit': {'change'},
-        'delete': {'delete'},
         'bulk_edit': {'change'},
         'bulk_delete': {'delete'},
     }


### PR DESCRIPTION
### Fixes: #151 - Remove edit and delete actions from SupportContractAssignmentListView

* Remove edit and delete button from the SupportContractAssignmentListView.