### PR TITLE
Fixes: #161 - Use correct `display_attrs` on `SupportSKUIndex` and `SupportContractIndex`

### DIFF
--- a/netbox_lifecycle/search.py
+++ b/netbox_lifecycle/search.py
@@ -22,7 +22,7 @@ class SupportSKUIndex(SearchIndex):
         ('description', 4000),
         ('comments', 5000),
     )
-    display_attrs = ('vendor', 'description')
+    display_attrs = ('manufacturer', 'description')
 
 
 @register_search
@@ -33,7 +33,7 @@ class SupportContractIndex(SearchIndex):
         ('description', 4000),
         ('comments', 5000),
     )
-    display_attrs = ('contract', 'sku', 'device', 'license', 'description')
+    display_attrs = ('vendor', 'start', 'renewal', 'end', 'description')
 
 
 @register_search

--- a/netbox_lifecycle/tests/test_search.py
+++ b/netbox_lifecycle/tests/test_search.py
@@ -15,6 +15,42 @@ class SearchIndexDisplayAttrsTestCase(TestCase):
     Search error "SupportContractAssignment has no field named 'vendor'"
     """
 
+    def test_support_sku_display_attrs_are_valid_fields(self):
+        """
+        SupportSKUIndex.display_attrs should only reference
+        fields that exist on the SupportSKU model.
+        """
+        index = SupportSKUIndex()
+        model = index.model
+
+        for attr in index.display_attrs:
+            # This should not raise FieldDoesNotExist
+            try:
+                model._meta.get_field(attr)
+            except FieldDoesNotExist:
+                self.fail(
+                    f"SupportSKUIndex.display_attrs references "
+                    f"non-existent field '{attr}' on {model.__name__}"
+                )
+
+    def test_support_contract_display_attrs_are_valid_fields(self):
+        """
+        SupportContractIndex.display_attrs should only reference
+        fields that exist on the SupportContract model.
+        """
+        index = SupportContractIndex()
+        model = index.model
+
+        for attr in index.display_attrs:
+            # This should not raise FieldDoesNotExist
+            try:
+                model._meta.get_field(attr)
+            except FieldDoesNotExist:
+                self.fail(
+                    f"SupportContractIndex.display_attrs references "
+                    f"non-existent field '{attr}' on {model.__name__}"
+                )
+
     def test_support_contract_assignment_display_attrs_are_valid_fields(self):
         """
         SupportContractAssignmentIndex.display_attrs should only reference

--- a/netbox_lifecycle/tests/test_search.py
+++ b/netbox_lifecycle/tests/test_search.py
@@ -4,6 +4,8 @@ from django.test import TestCase
 from netbox_lifecycle.search import (
     LicenseAssignmentIndex,
     SupportContractAssignmentIndex,
+    SupportContractIndex,
+    SupportSKUIndex,
 )
 
 


### PR DESCRIPTION
### Fixes: #161 - Use correct `display_attrs` on `SupportSKUIndex` and `SupportContractIndex`

Searches matching SupportSKU or SupportContract cause `FieldDoesNotExist` errors.

This PR corrects the values and adds a test case to `tests_search.py`.