### PR TITLE
Fixes: #168 - Add `extras.view_tag` permission to `VendorTest.test_create_vendor_with_tags`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: 'netbox-community/netbox'
-        ref: 'main'
+        ref: 'v4.6.7'
         path: 'netbox'
 
 

--- a/netbox_lifecycle/tests/test_api.py
+++ b/netbox_lifecycle/tests/test_api.py
@@ -51,7 +51,7 @@ class VendorTest(APIViewTestCases.APIViewTestCase):
 
     def test_create_vendor_with_tags(self):
         """Test creating a vendor with tags via the API."""
-        self.add_permissions('netbox_lifecycle.add_vendor')
+        self.add_permissions('netbox_lifecycle.add_vendor', 'extras.view_tag')
         Tag.objects.create(name='Test Tag', slug='test-tag')
         url = reverse('plugins-api:netbox_lifecycle-api:vendor-list')
         data = {


### PR DESCRIPTION
### Fixes: #168 - Add `extras.view_tag` permission to `VendorTest.test_create_vendor_with_tags`

In `ci.yml`, pins NetBox checkout to tag v4.6.7 instead of main to ensure reproducible testing.